### PR TITLE
Handle empty patient validation and fix display tests

### DIFF
--- a/clinicq_frontend/src/App.test.jsx
+++ b/clinicq_frontend/src/App.test.jsx
@@ -396,9 +396,9 @@ describe('Clinic Queue Full Workflow Test', () => {
     
     // Should show multiple visits and "Next in Queue" section
     await waitFor(() => {
-      expect(screen.getByText(/First Patient/)).toBeInTheDocument();
-      expect(screen.getByText(/Second Patient/)).toBeInTheDocument();
-      expect(screen.getByText(/Third Patient/)).toBeInTheDocument();
+      expect(screen.getAllByText(/First Patient/)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(/Second Patient/)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(/Third Patient/)[0]).toBeInTheDocument();
     }, { timeout: 3000 });
     
     axiosGet.mockRestore();

--- a/clinicq_frontend/src/pages/AssistantPage.jsx
+++ b/clinicq_frontend/src/pages/AssistantPage.jsx
@@ -62,7 +62,7 @@ const AssistantPage = () => {
       <Link to="/" className="text-blue-500 hover:underline mb-4 block">&larr; Back to Home</Link>
       <h1 className="text-3xl font-bold mb-6 text-center text-gray-700">Assistant Portal</h1>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleSubmit} noValidate className="space-y-4">
         <div>
           <label htmlFor="patientName" className="block text-sm font-medium text-gray-700">
             Patient Name


### PR DESCRIPTION
## Summary
- Ensure Assistant Portal form submits without native validation so custom empty patient message appears
- Adjust public display workflow test to tolerate duplicate patient names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a328771b1083238c5c29e6bb00c7e6