### PR TITLE
feat: filter visits by queue

### DIFF
--- a/clinicq_frontend/src/App.test.jsx
+++ b/clinicq_frontend/src/App.test.jsx
@@ -301,10 +301,18 @@ describe('Clinic Queue Full Workflow Test', () => {
   });
 
   test('doctor page handles API errors gracefully', async () => {
-    // Mock axios to simulate fetch error  
+    // Mock axios to simulate fetch error
     const originalAxios = require('axios');
     const axiosGet = jest.spyOn(originalAxios, 'get');
-    axiosGet.mockRejectedValueOnce(new Error('Network error'));
+    axiosGet.mockImplementation((url) => {
+      if (url.includes('/api/queues/')) {
+        return Promise.resolve({ data: [], status: 200 });
+      }
+      if (url.includes('/api/visits/')) {
+        return Promise.reject(new Error('Network error'));
+      }
+      return Promise.resolve({ data: [], status: 200 });
+    });
     
     const user = userEvent.setup();
     render(
@@ -326,17 +334,24 @@ describe('Clinic Queue Full Workflow Test', () => {
     const originalAxios = require('axios');
     const axiosGet = jest.spyOn(originalAxios, 'get');
     const axiosPatch = jest.spyOn(originalAxios, 'patch');
-    
-    axiosGet.mockResolvedValue({
-      data: [{
-        id: 1,
-        token_number: 1,
-        patient_name: 'Test Patient',
-        patient_gender: 'MALE',
-        visit_date: '2025-07-07',
-        status: 'WAITING',
-      }],
-      status: 200,
+
+    axiosGet.mockImplementation((url) => {
+      if (url.includes('/api/queues/')) {
+        return Promise.resolve({ data: [], status: 200 });
+      }
+      return Promise.resolve({
+        data: [
+          {
+            id: 1,
+            token_number: 1,
+            patient_name: 'Test Patient',
+            patient_gender: 'MALE',
+            visit_date: '2025-07-07',
+            status: 'WAITING',
+          },
+        ],
+        status: 200,
+      });
     });
     
     axiosPatch.mockRejectedValueOnce({

--- a/clinicq_frontend/src/pages/PublicDisplayPage.jsx
+++ b/clinicq_frontend/src/pages/PublicDisplayPage.jsx
@@ -8,28 +8,46 @@ const PublicDisplayPage = () => {
   const [waitingVisits, setWaitingVisits] = useState([]);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(true); // Start loading initially
+  const [queues, setQueues] = useState([]);
+  const [selectedQueue, setSelectedQueue] = useState('');
 
-  const fetchWaitingVisits = useCallback(async (isInitialLoad = false) => {
-    if (!isInitialLoad) setIsLoading(true); // Show loading indicator for manual refresh, not for auto-refresh unless it's the first one
-    setError('');
-    try {
-      const response = await axios.get('/api/visits/?status=WAITING');
-      setWaitingVisits(response.data || []);
-    } catch (err) {
-      console.error("Error fetching waiting visits:", err);
-      setError('Failed to fetch queue. Retrying...');
-      // Keep existing data on error during auto-refresh, clear if manual or initial
-      if (isInitialLoad) setWaitingVisits([]);
-    } finally {
-      setIsLoading(false);
-    }
+  const fetchWaitingVisits = useCallback(
+    async (isInitialLoad = false) => {
+      if (!isInitialLoad) setIsLoading(true); // Show loading indicator for manual refresh, not for auto-refresh unless it's the first one
+      setError('');
+      try {
+        const queueParam = selectedQueue ? `&queue=${selectedQueue}` : '';
+        const response = await axios.get(`/api/visits/?status=WAITING${queueParam}`);
+        setWaitingVisits(response.data || []);
+      } catch (err) {
+        console.error("Error fetching waiting visits:", err);
+        setError('Failed to fetch queue. Retrying...');
+        // Keep existing data on error during auto-refresh, clear if manual or initial
+        if (isInitialLoad) setWaitingVisits([]);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [selectedQueue]
+  );
+
+  useEffect(() => {
+    const fetchQueues = async () => {
+      try {
+        const response = await axios.get('/api/queues/');
+        setQueues(response.data || []);
+      } catch (err) {
+        console.error('Error fetching queues:', err);
+      }
+    };
+    fetchQueues();
   }, []);
 
   useEffect(() => {
     fetchWaitingVisits(true); // Initial fetch
 
     const intervalId = setInterval(() => {
-        fetchWaitingVisits(false); // Subsequent auto-refreshes
+      fetchWaitingVisits(false); // Subsequent auto-refreshes
     }, REFRESH_INTERVAL);
 
     return () => clearInterval(intervalId); // Cleanup interval on component unmount
@@ -40,6 +58,25 @@ const PublicDisplayPage = () => {
       <div className="flex justify-between items-center mb-6">
         <h1 className="text-3xl sm:text-4xl font-bold text-gray-800">Now Serving</h1>
         <Link to="/" className="text-sm text-blue-500 hover:underline hidden sm:block">Admin Home</Link>
+      </div>
+
+      <div className="mb-4">
+        <label htmlFor="queue-select" className="block text-sm font-medium text-gray-700">
+          Select Queue
+        </label>
+        <select
+          id="queue-select"
+          value={selectedQueue}
+          onChange={(e) => setSelectedQueue(e.target.value)}
+          className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+        >
+          <option value="">All Queues</option>
+          {queues.map((queue) => (
+            <option key={queue.id} value={queue.id}>
+              {queue.name}
+            </option>
+          ))}
+        </select>
       </div>
 
       {isLoading && waitingVisits.length === 0 && (
@@ -69,6 +106,11 @@ const PublicDisplayPage = () => {
               <div className="flex justify-between items-baseline">
                 <p className={`text-3xl sm:text-4xl font-extrabold ${index === 0 ? 'text-yellow-300' : 'text-blue-500'}`}>
                   {visit.token_number}
+                  {visit.queue_name && (
+                    <span className={`ml-2 text-sm font-normal ${index === 0 ? 'text-blue-100' : 'text-gray-500'}`}>
+                      {visit.queue_name}
+                    </span>
+                  )}
                 </p>
                 <p className={`text-sm sm:text-base font-medium ${index === 0 ? 'text-blue-100' : 'text-gray-500'}`}>
                   {visit.patient_name}
@@ -90,6 +132,7 @@ const PublicDisplayPage = () => {
             {waitingVisits.slice(1, 4).map(visit => ( // Show next 3
                  <p key={visit.id} className="text-lg text-gray-600">
                     Token <span className="font-bold">{visit.token_number}</span> - {visit.patient_name}
+                    {visit.queue_name && ` (${visit.queue_name})`}
                  </p>
             ))}
             {waitingVisits.length > 4 && <p className="text-sm text-gray-500">and more...</p>}


### PR DESCRIPTION
## Summary
- allow doctor and public pages to filter visits by queue
- request waiting visits for selected queue and show queue name
- update tests for new queue filtering

## Testing
- `npm test` *(fails: Jest: "global" coverage threshold for statements (80%) not met: 57.14%)*
- `pytest` *(fails: No module named 'django_test_migrations')*


------
https://chatgpt.com/codex/tasks/task_e_68a38c5640648323beadfab71a567ba4