### PR TITLE
docs: add contributing guidelines and MIT license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to ClinicQ
+
+Thanks for considering contributing to ClinicQ. This document outlines how to set up your environment, coding standards, and the workflow for submitting changes.
+
+## Development Workflow
+
+1. Fork the repository and create a feature branch from `main`:
+   ```bash
+   git checkout -b feature/my-feature
+   ```
+2. Set up the development environment. The recommended way is using Docker Compose:
+   ```bash
+   docker-compose up --build
+   ```
+3. Make your changes in the appropriate backend or frontend directories.
+4. Run tests and linters before committing:
+   - **Backend**: `pytest`
+   - **Frontend**: `npm test -- --watchAll=false`
+5. Ensure code is formatted and linted:
+   - **Python**: use `black` and `flake8`
+   - **JavaScript/TypeScript**: use `eslint` and `prettier`
+6. Commit with clear messages and push the branch to your fork.
+7. Open a pull request describing your changes and the tests you ran.
+
+## Code Standards
+
+- Follow [PEP 8](https://pep8.org/) for Python code and format using `black` (default line length).
+- Use `eslint` with the project's configuration for JavaScript/TypeScript.
+- Write or update tests for new features or bug fixes.
+- Update documentation and the changelog when appropriate.
+
+## Pull Requests
+
+- Each pull request should focus on a single change or fix.
+- The pull request description should summarize the change and reference related issues.
+- All tests and lint checks must pass before the pull request is reviewed.
+
+Thank you for contributing!
+

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 ClinicQ contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
## Summary
- document development workflow and standards in CONTRIBUTING.md
- add MIT License text

## Testing
- `pytest` *(fails: Requested setting REST_FRAMEWORK, but settings are not configured)*
- `cd clinicq_frontend && npm test -- --watchAll=false` *(fails: Jest coverage thresholds not met)*

------
https://chatgpt.com/codex/tasks/task_e_68a38a3b67948323bb89c17a306dc09f