### PR TITLE
Support queue query parameter on public display

### DIFF
--- a/clinicq_frontend/src/App.jsx
+++ b/clinicq_frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, Link } from 'react-router-dom'; // Removed BrowserRouter as Router
+import { Routes, Route, Link, useSearchParams } from 'react-router-dom'; // Removed BrowserRouter as Router
 import AssistantPage from './pages/AssistantPage';
 import DoctorPage from './pages/DoctorPage'; // Placeholder for now
 import PublicDisplayPage from './pages/PublicDisplayPage'; // Placeholder for now
@@ -22,6 +22,12 @@ const HomePage = () => (
   </div>
 );
 
+const PublicDisplayRoute = () => {
+  const [searchParams] = useSearchParams();
+  const queue = searchParams.get('queue') || '';
+  return <PublicDisplayPage initialQueue={queue} />;
+};
+
 
 function App() {
   return (
@@ -31,7 +37,7 @@ function App() {
         <Route path="/" element={<HomePage />} />
         <Route path="/assistant" element={<AssistantPage />} />
         <Route path="/doctor" element={<DoctorPage />} />
-        <Route path="/display" element={<PublicDisplayPage />} />
+        <Route path="/display" element={<PublicDisplayRoute />} />
         <Route path="/patients" element={<PatientsPage />} />
         <Route path="/patients/new" element={<PatientFormPage />} />
         <Route path="/patients/:registration_number/edit" element={<PatientFormPage />} />

--- a/clinicq_frontend/src/pages/AssistantPage.jsx
+++ b/clinicq_frontend/src/pages/AssistantPage.jsx
@@ -47,27 +47,6 @@ const AssistantPage = () => {
       }
     };
     const handler = setTimeout(() => {
-      const fetchPatient = async () => {
-        if (!registrationNumber.trim()) {
-          setPatientInfo(null);
-          return;
-        }
-        try {
-          const searchResp = await axios.get(
-            `/api/patients/search/?q=${encodeURIComponent(registrationNumber.trim())}`
-          );
-          if (Array.isArray(searchResp.data) && searchResp.data.length > 0) {
-            const regNo = searchResp.data[0].registration_number;
-            const detailResp = await axios.get(`/api/patients/${regNo}/`);
-            setPatientInfo(detailResp.data);
-          } else {
-            setPatientInfo(null);
-          }
-        } catch (err) {
-          console.error('Error fetching patient:', err);
-          setPatientInfo(null);
-        }
-      };
       fetchPatient();
     }, 500); // 500ms debounce
     return () => clearTimeout(handler);

--- a/clinicq_frontend/src/pages/DoctorPage.jsx
+++ b/clinicq_frontend/src/pages/DoctorPage.jsx
@@ -32,6 +32,21 @@ const DoctorPage = () => {
             acc[patient.registration_number] = patient;
             return acc;
           }, {});
+          const missingRegs = registrationNumbers.filter(
+            (regNum) => !patientsByRegNum[regNum]
+          );
+          if (missingRegs.length > 0) {
+            await Promise.all(
+              missingRegs.map(async (regNum) => {
+                try {
+                  const resp = await axios.get(`/api/patients/${regNum}/`);
+                  patientsByRegNum[regNum] = resp.data;
+                } catch {
+                  patientsByRegNum[regNum] = null;
+                }
+              })
+            );
+          }
         } catch {
           // If batch fetch fails, fallback to individual requests
           await Promise.all(

--- a/clinicq_frontend/src/pages/PublicDisplayPage.jsx
+++ b/clinicq_frontend/src/pages/PublicDisplayPage.jsx
@@ -4,12 +4,12 @@ import { Link } from 'react-router-dom';
 
 const REFRESH_INTERVAL = 5000; // 5 seconds
 
-const PublicDisplayPage = () => {
+const PublicDisplayPage = ({ initialQueue = '' }) => {
   const [waitingVisits, setWaitingVisits] = useState([]);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(true); // Start loading initially
   const [queues, setQueues] = useState([]);
-  const [selectedQueue, setSelectedQueue] = useState('');
+  const [selectedQueue, setSelectedQueue] = useState(initialQueue);
 
   const fetchWaitingVisits = useCallback(
     async (isInitialLoad = false) => {
@@ -30,6 +30,10 @@ const PublicDisplayPage = () => {
     },
     [selectedQueue]
   );
+
+  useEffect(() => {
+    setSelectedQueue(initialQueue);
+  }, [initialQueue]);
 
   useEffect(() => {
     const fetchQueues = async () => {


### PR DESCRIPTION
## Summary
- parse `queue` query string and forward to PublicDisplayPage
- initialize public display with given queue and refresh automatically
- clean up patient fetching and add patient-detail fallback to keep lint/tests passing

## Testing
- `cd clinicq_frontend && npm test`
- `cd clinicq_frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a39c4321f48323bc4e01a0f114ddcb