### PR TITLE
Handle Google API errors in prescription uploads

### DIFF
--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -166,7 +166,6 @@ class PrescriptionImageViewSet(viewsets.ModelViewSet):
         try:
             file_id, file_url = upload_prescription_image(image_file)
         except Exception as e:
-            logger = logging.getLogger(__name__)
             if isinstance(e, GoogleApiError):
                 logger.error(
                     f"Google API error while uploading prescription image: {e}",

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -8,10 +8,12 @@ from .serializers import (
     PrescriptionImageSerializer,
 )
 from django.utils import timezone
-import datetime # Required for date operations
-from django.db.models import Q # For complex lookups (patient search)
+import datetime  # Required for date operations
+from django.db.models import Q  # For complex lookups (patient search)
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.shortcuts import get_object_or_404
+import logging
+from googleapiclient.errors import HttpError as GoogleApiError
 from .google_drive import upload_prescription_image
 
 
@@ -163,13 +165,18 @@ class PrescriptionImageViewSet(viewsets.ModelViewSet):
         file_url = ''
         try:
             file_id, file_url = upload_prescription_image(image_file)
-        except Exception:
         except Exception as e:
             logger = logging.getLogger(__name__)
-            if 'GoogleApiError' in globals() and GoogleApiError and isinstance(e, GoogleApiError):
-                logger.error(f"Google API error while uploading prescription image: {e}", exc_info=True)
+            if isinstance(e, GoogleApiError):
+                logger.error(
+                    f"Google API error while uploading prescription image: {e}",
+                    exc_info=True,
+                )
             else:
-                logger.error(f"Unexpected error while uploading prescription image: {e}", exc_info=True)
+                logger.error(
+                    f"Unexpected error while uploading prescription image: {e}",
+                    exc_info=True,
+                )
         instance = PrescriptionImage.objects.create(
             visit=visit, drive_file_id=file_id or '', image_url=file_url or ''
         )


### PR DESCRIPTION
## Summary
- import `GoogleApiError` and log it explicitly
- remove stray exception clause in prescription image upload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3a431f5488323b12523f455706aae