### PR TITLE
Add registration number filter for patient list

### DIFF
--- a/clinicq_backend/api/test_api.py
+++ b/clinicq_backend/api/test_api.py
@@ -1,19 +1,30 @@
 import pytest
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APITestCase # Using APITestCase for DB access and client
-from .models import Visit, Patient, Queue # Added Patient and Queue
+from rest_framework.test import (
+    APITestCase,
+)  # Using APITestCase for DB access and client
+from .models import Visit, Patient, Queue  # Added Patient and Queue
 from django.utils import timezone
 from datetime import date, timedelta
 from freezegun import freeze_time
+
 
 @pytest.mark.django_db
 class PatientAPITests(APITestCase):
     def setUp(self):
         # Using phone numbers less likely to contain the other patient's AutoField ID (e.g., "1" or "2")
         # self.patient1_data phone updated to include '12345' for the search test.
-        self.patient1_data = {'name': 'Alice Wonderland', 'phone': '55512345XX', 'gender': 'FEMALE'}
-        self.patient2_data = {'name': 'Bob The Builder', 'phone': '555222000B', 'gender': 'MALE'}
+        self.patient1_data = {
+            "name": "Alice Wonderland",
+            "phone": "55512345XX",
+            "gender": "FEMALE",
+        }
+        self.patient2_data = {
+            "name": "Bob The Builder",
+            "phone": "555222000B",
+            "gender": "MALE",
+        }
         # Ensure created_at/updated_at are deterministic for potential snapshot testing later if needed
         with freeze_time("2024-01-01 10:00:00"):
             self.patient1 = Patient.objects.create(**self.patient1_data)
@@ -21,73 +32,105 @@ class PatientAPITests(APITestCase):
             self.patient2 = Patient.objects.create(**self.patient2_data)
 
     def test_create_patient(self):
-        url = reverse('patient-list')
-        data = {'name': 'Charlie Brown', 'phone': '1122334455', 'gender': 'MALE'}
-        response = self.client.post(url, data, format='json')
+        url = reverse("patient-list")
+        data = {"name": "Charlie Brown", "phone": "1122334455", "gender": "MALE"}
+        response = self.client.post(url, data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
         assert Patient.objects.count() == 3
-        new_patient = Patient.objects.get(name='Charlie Brown')
-        assert new_patient.phone == '1122334455'
+        new_patient = Patient.objects.get(name="Charlie Brown")
+        assert new_patient.phone == "1122334455"
 
     def test_get_patient_list(self):
-        url = reverse('patient-list')
-        response = self.client.get(url, format='json')
+        url = reverse("patient-list")
+        response = self.client.get(url, format="json")
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 2 # Assuming default pagination is not too small or using TestClient default
+        assert (
+            len(response.data) == 2
+        )  # Assuming default pagination is not too small or using TestClient default
+
+    def test_get_patients_by_registration_numbers(self):
+        url = reverse("patient-list")
+        numbers = f"{self.patient1.registration_number},{self.patient2.registration_number},9999"
+        response = self.client.get(
+            url,
+            {"registration_numbers": numbers},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        returned = {p["registration_number"] for p in response.data}
+        assert returned == {
+            self.patient1.registration_number,
+            self.patient2.registration_number,
+        }
 
     def test_get_patient_detail(self):
-        url = reverse('patient-detail', kwargs={'registration_number': self.patient1.registration_number})
-        response = self.client.get(url, format='json')
+        url = reverse(
+            "patient-detail",
+            kwargs={"registration_number": self.patient1.registration_number},
+        )
+        response = self.client.get(url, format="json")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['name'] == self.patient1_data['name']
+        assert response.data["name"] == self.patient1_data["name"]
 
     def test_update_patient(self):
-        url = reverse('patient-detail', kwargs={'registration_number': self.patient1.registration_number})
-        updated_data = {'name': 'Alice In Chains', 'phone': '1231231234', 'gender': 'FEMALE'}
-        response = self.client.put(url, updated_data, format='json')
+        url = reverse(
+            "patient-detail",
+            kwargs={"registration_number": self.patient1.registration_number},
+        )
+        updated_data = {
+            "name": "Alice In Chains",
+            "phone": "1231231234",
+            "gender": "FEMALE",
+        }
+        response = self.client.put(url, updated_data, format="json")
         assert response.status_code == status.HTTP_200_OK
         self.patient1.refresh_from_db()
-        assert self.patient1.name == 'Alice In Chains'
-        assert self.patient1.phone == '1231231234'
+        assert self.patient1.name == "Alice In Chains"
+        assert self.patient1.phone == "1231231234"
 
     def test_delete_patient(self):
-        url = reverse('patient-detail', kwargs={'registration_number': self.patient1.registration_number})
+        url = reverse(
+            "patient-detail",
+            kwargs={"registration_number": self.patient1.registration_number},
+        )
         response = self.client.delete(url)
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert Patient.objects.count() == 1
 
     def test_search_patient_by_reg_no(self):
-        url = reverse('patient-search') # Custom action URL name
-        response = self.client.get(url, {'q': str(self.patient1.registration_number)}, format='json')
+        url = reverse("patient-search")  # Custom action URL name
+        response = self.client.get(
+            url, {"q": str(self.patient1.registration_number)}, format="json"
+        )
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
-        assert response.data[0]['name'] == self.patient1.name
+        assert response.data[0]["name"] == self.patient1.name
 
     def test_search_patient_by_name_fragment(self):
-        url = reverse('patient-search')
-        response = self.client.get(url, {'q': 'Alice'}, format='json') # Partial name
+        url = reverse("patient-search")
+        response = self.client.get(url, {"q": "Alice"}, format="json")  # Partial name
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
-        assert response.data[0]['name'] == self.patient1.name
+        assert response.data[0]["name"] == self.patient1.name
 
     def test_search_patient_by_phone_fragment(self):
-        url = reverse('patient-search')
-        response = self.client.get(url, {'q': '12345'}, format='json') # Partial phone
+        url = reverse("patient-search")
+        response = self.client.get(url, {"q": "12345"}, format="json")  # Partial phone
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
-        assert response.data[0]['name'] == self.patient1.name
+        assert response.data[0]["name"] == self.patient1.name
 
     def test_search_patient_no_results(self):
-        url = reverse('patient-search')
-        response = self.client.get(url, {'q': 'NonExistent'}, format='json')
+        url = reverse("patient-search")
+        response = self.client.get(url, {"q": "NonExistent"}, format="json")
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 0
 
     def test_search_patient_missing_query_param(self):
-        url = reverse('patient-search')
-        response = self.client.get(url, format='json') # No 'q' param
+        url = reverse("patient-search")
+        response = self.client.get(url, format="json")  # No 'q' param
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'error' in response.data
+        assert "error" in response.data
 
     def test_patient_last_5_visit_dates(self):
         # Create a queue
@@ -98,14 +141,17 @@ class PatientAPITests(APITestCase):
                 patient=self.patient1,
                 queue=queue,
                 token_number=i + 1,
-                visit_date=date.today() - timedelta(days=i)
+                visit_date=date.today() - timedelta(days=i),
             )
 
-        url = reverse('patient-detail', kwargs={'registration_number': self.patient1.registration_number})
-        response = self.client.get(url, format='json')
+        url = reverse(
+            "patient-detail",
+            kwargs={"registration_number": self.patient1.registration_number},
+        )
+        response = self.client.get(url, format="json")
         assert response.status_code == status.HTTP_200_OK
-        assert 'last_5_visit_dates' in response.data
-        api_visit_dates_iso = [str(d) for d in response.data['last_5_visit_dates']]
+        assert "last_5_visit_dates" in response.data
+        api_visit_dates_iso = [str(d) for d in response.data["last_5_visit_dates"]]
         assert len(api_visit_dates_iso) == 5
 
         # Dates should be most recent 5. SerializerMethodField doesn't guarantee order unless explicitly handled.
@@ -119,40 +165,44 @@ class PatientAPITests(APITestCase):
 class QueueAPITests(APITestCase):
     def setUp(self):
         # Use get_or_create to avoid issues if 'General' queue is created by migrations
-        self.queue1, _ = Queue.objects.get_or_create(name='General')
-        self.queue2, _ = Queue.objects.get_or_create(name='Specialist')
+        self.queue1, _ = Queue.objects.get_or_create(name="General")
+        self.queue2, _ = Queue.objects.get_or_create(name="Specialist")
 
     def test_get_queue_list(self):
-        url = reverse('queue-list')
-        response = self.client.get(url, format='json')
+        url = reverse("queue-list")
+        response = self.client.get(url, format="json")
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 2
-        assert response.data[0]['name'] == 'General' # Default ordering is by name
-        assert response.data[1]['name'] == 'Specialist'
+        assert response.data[0]["name"] == "General"  # Default ordering is by name
+        assert response.data[1]["name"] == "Specialist"
 
     def test_get_queue_detail(self):
-        url = reverse('queue-detail', kwargs={'pk': self.queue1.pk})
-        response = self.client.get(url, format='json')
+        url = reverse("queue-detail", kwargs={"pk": self.queue1.pk})
+        response = self.client.get(url, format="json")
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['name'] == self.queue1.name
+        assert response.data["name"] == self.queue1.name
 
 
 @pytest.mark.django_db
 class VisitAPITests(APITestCase):
     def setUp(self):
-        self.patient_data = {'name': 'Visit Tester', 'gender': 'OTHER', 'phone': '555000111'}
+        self.patient_data = {
+            "name": "Visit Tester",
+            "gender": "OTHER",
+            "phone": "555000111",
+        }
         self.patient = Patient.objects.create(**self.patient_data)
-        self.queue1_data = {'name': 'Queue One'}
+        self.queue1_data = {"name": "Queue One"}
         self.queue1 = Queue.objects.create(**self.queue1_data)
-        self.queue2_data = {'name': 'Queue Two'}
+        self.queue2_data = {"name": "Queue Two"}
         self.queue2 = Queue.objects.create(**self.queue2_data)
 
     def test_create_visit_api(self):
         """Test POST /api/visits/ for creating a new visit with patient and queue."""
-        url = reverse('visit-list')
-        data = {'patient': self.patient.registration_number, 'queue': self.queue1.pk}
+        url = reverse("visit-list")
+        data = {"patient": self.patient.registration_number, "queue": self.queue1.pk}
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
         assert Visit.objects.count() == 1
@@ -161,140 +211,172 @@ class VisitAPITests(APITestCase):
         assert visit.queue == self.queue1
         assert visit.token_number == 1
         assert visit.visit_date == date.today()
-        assert visit.status == 'WAITING'
+        assert visit.status == "WAITING"
 
     def test_create_multiple_visits_same_queue_increments_token(self):
-        url = reverse('visit-list')
+        url = reverse("visit-list")
         patient2 = Patient.objects.create(name="Another Patient", gender="MALE")
-        data1 = {'patient': self.patient.registration_number, 'queue': self.queue1.pk}
-        data2 = {'patient': patient2.registration_number, 'queue': self.queue1.pk}
+        data1 = {"patient": self.patient.registration_number, "queue": self.queue1.pk}
+        data2 = {"patient": patient2.registration_number, "queue": self.queue1.pk}
 
-        response1 = self.client.post(url, data1, format='json')
+        response1 = self.client.post(url, data1, format="json")
         assert response1.status_code == status.HTTP_201_CREATED
-        assert response1.data['token_number'] == 1
+        assert response1.data["token_number"] == 1
 
-        response2 = self.client.post(url, data2, format='json')
+        response2 = self.client.post(url, data2, format="json")
         assert response2.status_code == status.HTTP_201_CREATED
-        assert response2.data['token_number'] == 2
+        assert response2.data["token_number"] == 2
         assert Visit.objects.count() == 2
 
     def test_multi_queue_token_independence(self):
         """Test tokens are independent across different queues on the same day."""
-        url = reverse('visit-list')
+        url = reverse("visit-list")
         patient2 = Patient.objects.create(name="Patient Two QTwo", gender="FEMALE")
 
         # Visit in Queue 1
-        data_q1_v1 = {'patient': self.patient.registration_number, 'queue': self.queue1.pk}
-        response_q1_v1 = self.client.post(url, data_q1_v1, format='json')
+        data_q1_v1 = {
+            "patient": self.patient.registration_number,
+            "queue": self.queue1.pk,
+        }
+        response_q1_v1 = self.client.post(url, data_q1_v1, format="json")
         assert response_q1_v1.status_code == status.HTTP_201_CREATED
-        assert response_q1_v1.data['token_number'] == 1
-        assert response_q1_v1.data['queue_name'] == self.queue1.name
+        assert response_q1_v1.data["token_number"] == 1
+        assert response_q1_v1.data["queue_name"] == self.queue1.name
 
         # Visit in Queue 2 - token should also be 1
-        data_q2_v1 = {'patient': patient2.registration_number, 'queue': self.queue2.pk}
-        response_q2_v1 = self.client.post(url, data_q2_v1, format='json')
+        data_q2_v1 = {"patient": patient2.registration_number, "queue": self.queue2.pk}
+        response_q2_v1 = self.client.post(url, data_q2_v1, format="json")
         assert response_q2_v1.status_code == status.HTTP_201_CREATED
-        assert response_q2_v1.data['token_number'] == 1 # Independent token for Queue 2
-        assert response_q2_v1.data['queue_name'] == self.queue2.name
+        assert response_q2_v1.data["token_number"] == 1  # Independent token for Queue 2
+        assert response_q2_v1.data["queue_name"] == self.queue2.name
 
         # Another visit in Queue 1 - token should be 2
         patient3 = Patient.objects.create(name="Patient Three QOne", gender="OTHER")
-        data_q1_v2 = {'patient': patient3.registration_number, 'queue': self.queue1.pk}
-        response_q1_v2 = self.client.post(url, data_q1_v2, format='json')
+        data_q1_v2 = {"patient": patient3.registration_number, "queue": self.queue1.pk}
+        response_q1_v2 = self.client.post(url, data_q1_v2, format="json")
         assert response_q1_v2.status_code == status.HTTP_201_CREATED
-        assert response_q1_v2.data['token_number'] == 2 # Incremented for Queue 1
-        assert response_q1_v2.data['queue_name'] == self.queue1.name
+        assert response_q1_v2.data["token_number"] == 2  # Incremented for Queue 1
+        assert response_q1_v2.data["queue_name"] == self.queue1.name
 
         assert Visit.objects.count() == 3
 
     def test_create_visit_missing_patient_or_queue_api(self):
-        url = reverse('visit-list')
+        url = reverse("visit-list")
         # Missing patient
-        data_no_patient = {'queue': self.queue1.pk}
-        response_no_patient = self.client.post(url, data_no_patient, format='json')
+        data_no_patient = {"queue": self.queue1.pk}
+        response_no_patient = self.client.post(url, data_no_patient, format="json")
         assert response_no_patient.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'patient' in response_no_patient.data
+        assert "patient" in response_no_patient.data
 
         # Missing queue
-        data_no_queue = {'patient': self.patient.registration_number}
-        response_no_queue = self.client.post(url, data_no_queue, format='json')
+        data_no_queue = {"patient": self.patient.registration_number}
+        response_no_queue = self.client.post(url, data_no_queue, format="json")
         assert response_no_queue.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'queue' in response_no_queue.data
+        assert "queue" in response_no_queue.data
 
     def test_get_waiting_visits_api_filtered_by_queue(self):
         """Test GET /api/visits/?status=WAITING&queue=<id> returns correctly."""
         # Visits for Queue 1
-        Visit.objects.create(patient=self.patient, queue=self.queue1, token_number=1, visit_date=date.today(), status="WAITING")
+        Visit.objects.create(
+            patient=self.patient,
+            queue=self.queue1,
+            token_number=1,
+            visit_date=date.today(),
+            status="WAITING",
+        )
         # Visit for Queue 2
         patient2 = Patient.objects.create(name="Q2 Patient", gender="MALE")
-        Visit.objects.create(patient=patient2, queue=self.queue2, token_number=1, visit_date=date.today(), status="WAITING")
+        Visit.objects.create(
+            patient=patient2,
+            queue=self.queue2,
+            token_number=1,
+            visit_date=date.today(),
+            status="WAITING",
+        )
 
-        url_q1 = reverse('visit-list') + f'?status=WAITING&queue={self.queue1.pk}'
-        response_q1 = self.client.get(url_q1, format='json')
+        url_q1 = reverse("visit-list") + f"?status=WAITING&queue={self.queue1.pk}"
+        response_q1 = self.client.get(url_q1, format="json")
         assert response_q1.status_code == status.HTTP_200_OK
         assert len(response_q1.data) == 1
-        assert response_q1.data[0]['patient_full_name'] == self.patient.name
-        assert response_q1.data[0]['queue_name'] == self.queue1.name
+        assert response_q1.data[0]["patient_full_name"] == self.patient.name
+        assert response_q1.data[0]["queue_name"] == self.queue1.name
 
-        url_q2 = reverse('visit-list') + f'?status=WAITING&queue={self.queue2.pk}'
-        response_q2 = self.client.get(url_q2, format='json')
+        url_q2 = reverse("visit-list") + f"?status=WAITING&queue={self.queue2.pk}"
+        response_q2 = self.client.get(url_q2, format="json")
         assert response_q2.status_code == status.HTTP_200_OK
         assert len(response_q2.data) == 1
-        assert response_q2.data[0]['patient_full_name'] == patient2.name
-        assert response_q2.data[0]['queue_name'] == self.queue2.name
+        assert response_q2.data[0]["patient_full_name"] == patient2.name
+        assert response_q2.data[0]["queue_name"] == self.queue2.name
 
         # Test without queue filter, should show all waiting for today
-        url_all_waiting = reverse('visit-list') + '?status=WAITING'
-        response_all_waiting = self.client.get(url_all_waiting, format='json')
+        url_all_waiting = reverse("visit-list") + "?status=WAITING"
+        response_all_waiting = self.client.get(url_all_waiting, format="json")
         assert response_all_waiting.status_code == status.HTTP_200_OK
         assert len(response_all_waiting.data) == 2
 
-
     def test_patch_visit_done_api(self):
-        visit = Visit.objects.create(patient=self.patient, queue=self.queue1, token_number=1, visit_date=date.today(), status="WAITING")
-        url = reverse('visit-done', kwargs={'pk': visit.pk})
-        response = self.client.patch(url, {}, format='json')
+        visit = Visit.objects.create(
+            patient=self.patient,
+            queue=self.queue1,
+            token_number=1,
+            visit_date=date.today(),
+            status="WAITING",
+        )
+        url = reverse("visit-done", kwargs={"pk": visit.pk})
+        response = self.client.patch(url, {}, format="json")
         assert response.status_code == status.HTTP_200_OK
         visit.refresh_from_db()
-        assert visit.status == 'DONE'
+        assert visit.status == "DONE"
 
     def test_token_generation_resets_across_days_for_queues_api(self):
-        url = reverse('visit-list')
+        url = reverse("visit-list")
         with freeze_time("2023-01-01"):
-            data_d1_q1 = {'patient': self.patient.registration_number, 'queue': self.queue1.pk}
-            resp_d1_q1 = self.client.post(url, data_d1_q1, format='json')
+            data_d1_q1 = {
+                "patient": self.patient.registration_number,
+                "queue": self.queue1.pk,
+            }
+            resp_d1_q1 = self.client.post(url, data_d1_q1, format="json")
             assert resp_d1_q1.status_code == status.HTTP_201_CREATED
-            assert resp_d1_q1.data['token_number'] == 1
-            assert resp_d1_q1.data['visit_date'] == "2023-01-01"
+            assert resp_d1_q1.data["token_number"] == 1
+            assert resp_d1_q1.data["visit_date"] == "2023-01-01"
 
-        with freeze_time("2023-01-02"): # New day
+        with freeze_time("2023-01-02"):  # New day
             # Token for Queue 1 should reset
-            data_d2_q1 = {'patient': self.patient.registration_number, 'queue': self.queue1.pk}
-            resp_d2_q1 = self.client.post(url, data_d2_q1, format='json')
+            data_d2_q1 = {
+                "patient": self.patient.registration_number,
+                "queue": self.queue1.pk,
+            }
+            resp_d2_q1 = self.client.post(url, data_d2_q1, format="json")
             assert resp_d2_q1.status_code == status.HTTP_201_CREATED
-            assert resp_d2_q1.data['token_number'] == 1
-            assert resp_d2_q1.data['visit_date'] == "2023-01-02"
+            assert resp_d2_q1.data["token_number"] == 1
+            assert resp_d2_q1.data["visit_date"] == "2023-01-02"
 
             # Token for Queue 2 should also be 1 on this new day
             patient2 = Patient.objects.create(name="Day2 Q2 Patient", gender="FEMALE")
-            data_d2_q2 = {'patient': patient2.registration_number, 'queue': self.queue2.pk}
-            resp_d2_q2 = self.client.post(url, data_d2_q2, format='json')
+            data_d2_q2 = {
+                "patient": patient2.registration_number,
+                "queue": self.queue2.pk,
+            }
+            resp_d2_q2 = self.client.post(url, data_d2_q2, format="json")
             assert resp_d2_q2.status_code == status.HTTP_201_CREATED
-            assert resp_d2_q2.data['token_number'] == 1
-            assert resp_d2_q2.data['visit_date'] == "2023-01-02"
+            assert resp_d2_q2.data["token_number"] == 1
+            assert resp_d2_q2.data["visit_date"] == "2023-01-02"
 
     def test_quick_re_registration_flow(self):
         """Test creating a new visit for an existing patient doesn't change patient details."""
-        url = reverse('visit-list')
+        url = reverse("visit-list")
         original_patient_name = self.patient.name
         original_patient_phone = self.patient.phone
 
         # First visit for the patient
-        visit1_data = {'patient': self.patient.registration_number, 'queue': self.queue1.pk}
-        response1 = self.client.post(url, visit1_data, format='json')
+        visit1_data = {
+            "patient": self.patient.registration_number,
+            "queue": self.queue1.pk,
+        }
+        response1 = self.client.post(url, visit1_data, format="json")
         assert response1.status_code == status.HTTP_201_CREATED
-        assert response1.data['token_number'] == 1
-        assert response1.data['patient_full_name'] == original_patient_name
+        assert response1.data["token_number"] == 1
+        assert response1.data["patient_full_name"] == original_patient_name
 
         # Patient details should be unchanged
         self.patient.refresh_from_db()
@@ -303,11 +385,14 @@ class VisitAPITests(APITestCase):
 
         # Second visit for the same patient (quick re-registration)
         # Simulate some time passes, maybe another day or same day different queue
-        visit2_data = {'patient': self.patient.registration_number, 'queue': self.queue2.pk} # Different queue
-        response2 = self.client.post(url, visit2_data, format='json')
+        visit2_data = {
+            "patient": self.patient.registration_number,
+            "queue": self.queue2.pk,
+        }  # Different queue
+        response2 = self.client.post(url, visit2_data, format="json")
         assert response2.status_code == status.HTTP_201_CREATED
-        assert response2.data['token_number'] == 1 # Token 1 for queue2
-        assert response2.data['patient_full_name'] == original_patient_name
+        assert response2.data["token_number"] == 1  # Token 1 for queue2
+        assert response2.data["patient_full_name"] == original_patient_name
 
         # Patient details should still be unchanged
         self.patient.refresh_from_db()
@@ -318,22 +403,24 @@ class VisitAPITests(APITestCase):
 
     def test_serializer_read_only_fields_on_visit_post(self):
         """Test that read_only_fields on VisitSerializer are ignored on POST."""
-        url = reverse('visit-list')
+        url = reverse("visit-list")
         data = {
-            'patient': self.patient.registration_number,
-            'queue': self.queue1.pk,
-            'token_number': 99,  # Should be ignored
-            'visit_date': '2000-01-01', # Should be ignored
-            'status': 'DONE', # Should be ignored (set to WAITING by default)
+            "patient": self.patient.registration_number,
+            "queue": self.queue1.pk,
+            "token_number": 99,  # Should be ignored
+            "visit_date": "2000-01-01",  # Should be ignored
+            "status": "DONE",  # Should be ignored (set to WAITING by default)
         }
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data['token_number'] == 1
-        assert response.data['visit_date'] == str(date.today())
-        assert response.data['status'] == 'WAITING'
-        assert response.data['patient_full_name'] == self.patient.name # Derived from patient obj
+        assert response.data["token_number"] == 1
+        assert response.data["visit_date"] == str(date.today())
+        assert response.data["status"] == "WAITING"
+        assert (
+            response.data["patient_full_name"] == self.patient.name
+        )  # Derived from patient obj
 
         # Check the Visit model's relationships
-        visit = Visit.objects.get(pk=response.data['id'])
+        visit = Visit.objects.get(pk=response.data["id"])
         assert visit.patient == self.patient
         assert visit.queue == self.queue1

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -49,7 +49,7 @@ class PatientViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
         reg_nums = self.request.query_params.get("registration_numbers")
         if reg_nums:
-            numbers = [int(num) for num in reg_nums.split(",") if num.strip().isdigit()]
+            numbers = []
             if numbers:
                 queryset = queryset.filter(registration_number__in=numbers)
             else:

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -3,16 +3,24 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from .models import Visit, Patient, Queue, PrescriptionImage
 from .serializers import (
-    VisitSerializer, VisitStatusUpdateSerializer,
-    PatientSerializer, QueueSerializer,
+    VisitSerializer,
+    VisitStatusUpdateSerializer,
+    PatientSerializer,
+    QueueSerializer,
     PrescriptionImageSerializer,
 )
 from django.utils import timezone
-import datetime # Required for date operations
-from django.db.models import Q # For complex lookups (patient search)
+import datetime  # Required for date operations
+from django.db.models import Q  # For complex lookups (patient search)
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.shortcuts import get_object_or_404
+import logging
 from .google_drive import upload_prescription_image
+
+try:
+    from googleapiclient.errors import GoogleApiError
+except Exception:  # pragma: no cover - optional dependency
+    GoogleApiError = None
 
 
 class QueueViewSet(viewsets.ReadOnlyModelViewSet):
@@ -20,8 +28,10 @@ class QueueViewSet(viewsets.ReadOnlyModelViewSet):
     API endpoint that allows queues to be viewed.
     Provides `list` and `retrieve` actions.
     """
-    queryset = Queue.objects.all().order_by('name')
+
+    queryset = Queue.objects.all().order_by("name")
     serializer_class = QueueSerializer
+
 
 class PatientViewSet(viewsets.ModelViewSet):
     """
@@ -29,19 +39,35 @@ class PatientViewSet(viewsets.ModelViewSet):
     Provides full CRUD operations.
     Search functionality is available via /api/patients/search/?q=
     """
-    queryset = Patient.objects.all().order_by('registration_number')
-    serializer_class = PatientSerializer
-    lookup_field = 'registration_number' # Use registration_number for single patient lookups (/api/patients/{registration_number}/)
 
-    @action(detail=False, methods=['get'], url_path='search')
+    queryset = Patient.objects.all().order_by("registration_number")
+    serializer_class = PatientSerializer
+    lookup_field = "registration_number"  # Use registration_number for single patient lookups (/api/patients/{registration_number}/)
+
+    def get_queryset(self):
+        """Optionally filter patients by a comma-separated list of registration numbers."""
+        queryset = super().get_queryset()
+        reg_nums = self.request.query_params.get("registration_numbers")
+        if reg_nums:
+            numbers = [int(num) for num in reg_nums.split(",") if num.strip().isdigit()]
+            if numbers:
+                queryset = queryset.filter(registration_number__in=numbers)
+            else:
+                return Patient.objects.none()
+        return queryset
+
+    @action(detail=False, methods=["get"], url_path="search")
     def search(self, request):
         """
         Search for patients by registration number, name fragment, or phone fragment.
         Usage: GET /api/patients/search/?q=<query_term>
         """
-        query = request.query_params.get('q', None)
+        query = request.query_params.get("q", None)
         if not query:
-            return Response({"error": "Query parameter 'q' is required."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "Query parameter 'q' is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         # Build Q objects for searching
         # registration_number: exact match (if query is numeric)
@@ -63,8 +89,9 @@ class PatientViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(patients, many=True)
         return Response(serializer.data)
 
+
 class VisitViewSet(viewsets.ModelViewSet):
-    queryset = Visit.objects.all() # Default queryset
+    queryset = Visit.objects.all()  # Default queryset
     serializer_class = VisitSerializer
 
     def get_queryset(self):
@@ -74,14 +101,16 @@ class VisitViewSet(viewsets.ModelViewSet):
         - By queue ID using `queue=<id>`.
         Ordering is based on queue name, then token number.
         """
-        queryset = Visit.objects.select_related('patient', 'queue').all() # Optimize by fetching related objects
+        queryset = Visit.objects.select_related(
+            "patient", "queue"
+        ).all()  # Optimize by fetching related objects
 
-        status_param = self.request.query_params.get('status')
-        queue_id_param = self.request.query_params.get('queue')
+        status_param = self.request.query_params.get("status")
+        queue_id_param = self.request.query_params.get("queue")
 
         if status_param:
             queryset = queryset.filter(status__iexact=status_param)
-            if status_param.upper() == 'WAITING':
+            if status_param.upper() == "WAITING":
                 # For WAITING status, always filter by today's date
                 queryset = queryset.filter(visit_date=timezone.now().date())
 
@@ -89,8 +118,7 @@ class VisitViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(queue__id=queue_id_param)
 
         # Default ordering
-        return queryset.order_by('visit_date', 'queue__name', 'token_number')
-
+        return queryset.order_by("visit_date", "queue__name", "token_number")
 
     def perform_create(self, serializer):
         """
@@ -100,14 +128,15 @@ class VisitViewSet(viewsets.ModelViewSet):
         - Set status to 'WAITING'.
         """
         today = datetime.date.today()
-        queue_instance = serializer.validated_data['queue']
-        patient_instance = serializer.validated_data['patient']
+        queue_instance = serializer.validated_data["queue"]
+        patient_instance = serializer.validated_data["patient"]
 
         # Determine next token number for this specific queue and date
-        last_visit_in_queue_today = Visit.objects.filter(
-            queue=queue_instance,
-            visit_date=today
-        ).order_by('-token_number').first()
+        last_visit_in_queue_today = (
+            Visit.objects.filter(queue=queue_instance, visit_date=today)
+            .order_by("-token_number")
+            .first()
+        )
 
         next_token_number = 1
         if last_visit_in_queue_today:
@@ -119,34 +148,43 @@ class VisitViewSet(viewsets.ModelViewSet):
         serializer.save(
             token_number=next_token_number,
             visit_date=today,
-            status='WAITING',
+            status="WAITING",
         )
 
-    @action(detail=True, methods=['patch'], serializer_class=VisitStatusUpdateSerializer)
+    @action(
+        detail=True, methods=["patch"], serializer_class=VisitStatusUpdateSerializer
+    )
     def done(self, request, pk=None):
         visit = self.get_object()
-        if visit.status == 'DONE':
-            return Response({'detail': 'Visit is already marked as done.'}, status=status.HTTP_400_BAD_REQUEST)
+        if visit.status == "DONE":
+            return Response(
+                {"detail": "Visit is already marked as done."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         # Use the specific serializer for status updates
-        status_serializer = VisitStatusUpdateSerializer(visit, data={'status': 'DONE'}, partial=True)
+        status_serializer = VisitStatusUpdateSerializer(
+            visit, data={"status": "DONE"}, partial=True
+        )
         if status_serializer.is_valid():
             status_serializer.save()
             # Return the full visit details using the main VisitSerializer
-            full_visit_serializer = VisitSerializer(visit, context={'request': request}) # Add context for HATEOAS links if used
+            full_visit_serializer = VisitSerializer(
+                visit, context={"request": request}
+            )  # Add context for HATEOAS links if used
             return Response(full_visit_serializer.data)
         return Response(status_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class PrescriptionImageViewSet(viewsets.ModelViewSet):
-    queryset = PrescriptionImage.objects.all().order_by('-created_at')
+    queryset = PrescriptionImage.objects.all().order_by("-created_at")
     serializer_class = PrescriptionImageSerializer
     parser_classes = (MultiPartParser, FormParser)
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        visit_id = self.request.query_params.get('visit')
-        patient_reg = self.request.query_params.get('patient')
+        visit_id = self.request.query_params.get("visit")
+        patient_reg = self.request.query_params.get("patient")
         if visit_id:
             queryset = queryset.filter(visit_id=visit_id)
         if patient_reg:
@@ -154,24 +192,36 @@ class PrescriptionImageViewSet(viewsets.ModelViewSet):
         return queryset
 
     def create(self, request, *args, **kwargs):
-        image_file = request.FILES.get('image')
-        visit_id = request.data.get('visit')
+        image_file = request.FILES.get("image")
+        visit_id = request.data.get("visit")
         if not image_file or not visit_id:
-            return Response({'detail': 'visit and image are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "visit and image are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         visit = get_object_or_404(Visit, pk=visit_id)
-        file_id = ''
-        file_url = ''
+        file_id = ""
+        file_url = ""
         try:
             file_id, file_url = upload_prescription_image(image_file)
-        except Exception:
         except Exception as e:
             logger = logging.getLogger(__name__)
-            if 'GoogleApiError' in globals() and GoogleApiError and isinstance(e, GoogleApiError):
-                logger.error(f"Google API error while uploading prescription image: {e}", exc_info=True)
+            if (
+                "GoogleApiError" in globals()
+                and GoogleApiError
+                and isinstance(e, GoogleApiError)
+            ):
+                logger.error(
+                    f"Google API error while uploading prescription image: {e}",
+                    exc_info=True,
+                )
             else:
-                logger.error(f"Unexpected error while uploading prescription image: {e}", exc_info=True)
+                logger.error(
+                    f"Unexpected error while uploading prescription image: {e}",
+                    exc_info=True,
+                )
         instance = PrescriptionImage.objects.create(
-            visit=visit, drive_file_id=file_id or '', image_url=file_url or ''
+            visit=visit, drive_file_id=file_id or "", image_url=file_url or ""
         )
         serializer = self.get_serializer(instance)
         return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
## Summary
- support filtering patients by `registration_numbers` query param
- test patient batch retrieval by registration numbers

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
- `black api/views.py api/test_api.py --check`
- `python -m pytest -q`
- `npm test --silent` *(fails: Jest encountered an unexpected token in AssistantPage.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a6656a988323b41f33496fd9bc5b