### PR TITLE
Add backend and frontend test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,31 +126,33 @@ docker-compose down -v
 ## Running Tests
 
 ### Backend Tests
+Run the Django test suite using the built-in test runner:
+```bash
+cd clinicq_backend
+python manage.py test
+```
 
-Ensure Docker Compose services are running (or at least the `db` service if tests connect to it, though backend tests here use `APITestCase` which often sets up its own test DB).
-To run backend tests directly within the container:
+Alternatively, if you prefer `pytest` and have Docker running:
 ```bash
 docker-compose exec backend pytest
 ```
-Or, if your local Python environment is set up similarly to the Docker image and you have a local PostgreSQL instance or can configure tests to use SQLite:
+Or locally with a configured Python environment:
 ```bash
 cd clinicq_backend
 # Ensure virtualenv is active and dependencies installed
-# Set necessary environment variables (like DATABASE_URL if not using test DB settings)
 pytest
 ```
 
 ### Frontend Tests
-
-Frontend tests are currently configured but may face execution issues in some sandboxed environments. To run them:
-```bash
-docker-compose exec frontend npm test -- --watchAll=false
-```
-Or locally:
+Run the React test suite with:
 ```bash
 cd clinicq_frontend
-npm install # If not already done
-npm test -- --watchAll=false
+npm test
+```
+
+If you are running inside Docker or want to disable watch mode:
+```bash
+docker-compose exec frontend npm test -- --watchAll=false
 ```
 
 ## Project Structure

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -206,6 +206,7 @@ class PrescriptionImageViewSet(viewsets.ModelViewSet):
         try:
             file_id, file_url = upload_prescription_image(image_file)
         except Exception as e:
+            if GoogleApiError and isinstance(e, GoogleApiError):
                 logger.error(
                     f"Google API error while uploading prescription image: {e}",
                     exc_info=True,

--- a/clinicq_backend/tests/test_api.py
+++ b/clinicq_backend/tests/test_api.py
@@ -1,0 +1,70 @@
+from rest_framework.test import APITestCase
+from api.models import Patient, Queue
+
+class PatientCRUDTests(APITestCase):
+    def test_patient_crud(self):
+        # Create
+        create_resp = self.client.post('/api/patients/', {
+            'name': 'John Doe',
+            'gender': 'MALE',
+            'phone': '1234567890'
+        }, format='json')
+        self.assertEqual(create_resp.status_code, 201)
+        reg_no = create_resp.data['registration_number']
+
+        # Retrieve
+        get_resp = self.client.get(f'/api/patients/{reg_no}/')
+        self.assertEqual(get_resp.status_code, 200)
+        self.assertEqual(get_resp.data['name'], 'John Doe')
+
+        # Update
+        patch_resp = self.client.patch(
+            f'/api/patients/{reg_no}/',
+            {'phone': '0987654321'},
+            format='json'
+        )
+        self.assertEqual(patch_resp.status_code, 200)
+        self.assertEqual(patch_resp.data['phone'], '0987654321')
+
+        # Delete
+        del_resp = self.client.delete(f'/api/patients/{reg_no}/')
+        self.assertEqual(del_resp.status_code, 204)
+        self.assertFalse(Patient.objects.filter(registration_number=reg_no).exists())
+
+
+class VisitTests(APITestCase):
+    def setUp(self):
+        self.patient = Patient.objects.create(name='Alice', gender='FEMALE')
+        self.queue1, _ = Queue.objects.get_or_create(name='General')
+        self.queue2, _ = Queue.objects.get_or_create(name='Special')
+
+    def test_visit_creation_assigns_token(self):
+        resp1 = self.client.post('/api/visits/', {
+            'patient': self.patient.registration_number,
+            'queue': self.queue1.id
+        }, format='json')
+        self.assertEqual(resp1.status_code, 201)
+        self.assertEqual(resp1.data['token_number'], 1)
+
+        resp2 = self.client.post('/api/visits/', {
+            'patient': self.patient.registration_number,
+            'queue': self.queue1.id
+        }, format='json')
+        self.assertEqual(resp2.status_code, 201)
+        self.assertEqual(resp2.data['token_number'], 2)
+
+    def test_queue_filter_returns_only_selected_queue(self):
+        # Create visits in two queues
+        self.client.post('/api/visits/', {
+            'patient': self.patient.registration_number,
+            'queue': self.queue1.id
+        }, format='json')
+        self.client.post('/api/visits/', {
+            'patient': self.patient.registration_number,
+            'queue': self.queue2.id
+        }, format='json')
+
+        resp = self.client.get(f'/api/visits/?status=WAITING&queue={self.queue1.id}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data), 1)
+        self.assertEqual(resp.data[0]['queue'], self.queue1.id)

--- a/clinicq_frontend/src/__tests__/AssistantPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/AssistantPage.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AssistantPage from '../pages/AssistantPage';
+import axios from 'axios';
+
+jest.mock('axios');
+
+test('renders Assistant portal heading', async () => {
+  axios.get.mockResolvedValue({ data: [] });
+  render(
+    <MemoryRouter>
+      <AssistantPage />
+    </MemoryRouter>
+  );
+  expect(await screen.findByText(/Assistant Portal/i)).toBeInTheDocument();
+});

--- a/clinicq_frontend/src/__tests__/DoctorPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/DoctorPage.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DoctorPage from '../pages/DoctorPage';
+import axios from 'axios';
+
+jest.mock('axios');
+
+test('renders Doctor dashboard heading', async () => {
+  axios.get.mockResolvedValue({ data: [] });
+  render(
+    <MemoryRouter>
+      <DoctorPage />
+    </MemoryRouter>
+  );
+  expect(await screen.findByText(/Doctor Dashboard/i)).toBeInTheDocument();
+});

--- a/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
@@ -13,5 +13,4 @@ test('renders Public Display heading', async () => {
     </MemoryRouter>
   );
   expect(await screen.findByText(/Now Serving/i)).toBeInTheDocument();
-  unmount();
 });

--- a/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PublicDisplayPage from '../pages/PublicDisplayPage';
+import axios from 'axios';
+
+jest.mock('axios');
+
+test('renders Public Display heading', async () => {
+  axios.get.mockResolvedValue({ data: [] });
+  const { unmount } = render(
+    <MemoryRouter>
+      <PublicDisplayPage />
+    </MemoryRouter>
+  );
+  expect(await screen.findByText(/Now Serving/i)).toBeInTheDocument();
+  unmount();
+});


### PR DESCRIPTION
## Summary
- add Django tests for patient CRUD and visit queue behaviour
- add React tests for Assistant, Doctor, and Public Display pages
- document npm and Django test commands and tidy prescription upload error handling

## Testing
- `python manage.py test tests`
- `npm test -- src/__tests__/AssistantPage.test.jsx src/__tests__/DoctorPage.test.jsx src/__tests__/PublicDisplayPage.test.jsx src/App.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a4f1a8959483239974d3232572bfe6