### PR TITLE
Fix error handling for prescription image upload

### DIFF
--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -203,15 +203,23 @@ class PrescriptionImageViewSet(viewsets.ModelViewSet):
         visit = get_object_or_404(Visit, pk=visit_id)
         file_id = ""
         file_url = ""
-        try:
-            file_id, file_url = upload_prescription_image(image_file)
-        except Exception as e:
-            if GoogleApiError and isinstance(e, GoogleApiError):
+        if GoogleApiError:
+            try:
+                file_id, file_url = upload_prescription_image(image_file)
+            except GoogleApiError as e:
                 logger.error(
                     f"Google API error while uploading prescription image: {e}",
                     exc_info=True,
                 )
-            else:
+            except Exception as e:
+                logger.error(
+                    f"Unexpected error while uploading prescription image: {e}",
+                    exc_info=True,
+                )
+        else:
+            try:
+                file_id, file_url = upload_prescription_image(image_file)
+            except Exception as e:
                 logger.error(
                     f"Unexpected error while uploading prescription image: {e}",
                     exc_info=True,


### PR DESCRIPTION
## Summary
- align error handlers when uploading prescription images to Google Drive

## Testing
- `pytest` *(fails: Requested setting REST_FRAMEWORK...; ModuleNotFoundError: No module named 'freezegun')*


------
https://chatgpt.com/codex/tasks/task_e_68a4fe58c3c083238306341239b8955f