### PR TITLE
Implement authentication and role-based access controls

### DIFF
--- a/clinicq_backend/api/permissions.py
+++ b/clinicq_backend/api/permissions.py
@@ -1,0 +1,22 @@
+from rest_framework import permissions
+
+class IsDoctor(permissions.BasePermission):
+    """Allows access only to users in the 'doctor' group."""
+
+    def has_permission(self, request, view):
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.groups.filter(name="doctor").exists()
+        )
+
+
+class IsAssistant(permissions.BasePermission):
+    """Allows access only to users in the 'assistant' group."""
+
+    def has_permission(self, request, view):
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.groups.filter(name="assistant").exists()
+        )

--- a/clinicq_backend/api/test_api.py
+++ b/clinicq_backend/api/test_api.py
@@ -1,10 +1,10 @@
 import pytest
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import (
-    APITestCase,
-)  # Using APITestCase for DB access and client
-from .models import Visit, Patient, Queue  # Added Patient and Queue
+from rest_framework.test import APITestCase
+from django.contrib.auth.models import User, Group
+from rest_framework.authtoken.models import Token
+from .models import Visit, Patient, Queue
 from django.utils import timezone
 from datetime import date, timedelta
 from freezegun import freeze_time
@@ -13,6 +13,12 @@ from freezegun import freeze_time
 @pytest.mark.django_db
 class PatientAPITests(APITestCase):
     def setUp(self):
+        doctor_group, _ = Group.objects.get_or_create(name="doctor")
+        assistant_group, _ = Group.objects.get_or_create(name="assistant")
+        user = User.objects.create_user(username="tester", password="pass")
+        user.groups.add(doctor_group, assistant_group)
+        token = Token.objects.create(user=user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
         # Using phone numbers less likely to contain the other patient's AutoField ID (e.g., "1" or "2")
         # self.patient1_data phone updated to include '12345' for the search test.
         self.patient1_data = {
@@ -164,6 +170,13 @@ class PatientAPITests(APITestCase):
 @pytest.mark.django_db
 class QueueAPITests(APITestCase):
     def setUp(self):
+        doctor_group, _ = Group.objects.get_or_create(name="doctor")
+        assistant_group, _ = Group.objects.get_or_create(name="assistant")
+        user = User.objects.create_user(username="queue_tester", password="pass")
+        user.groups.add(doctor_group, assistant_group)
+        token = Token.objects.create(user=user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
         # Use get_or_create to avoid issues if 'General' queue is created by migrations
         self.queue1, _ = Queue.objects.get_or_create(name="General")
         self.queue2, _ = Queue.objects.get_or_create(name="Specialist")
@@ -186,6 +199,13 @@ class QueueAPITests(APITestCase):
 @pytest.mark.django_db
 class VisitAPITests(APITestCase):
     def setUp(self):
+        doctor_group, _ = Group.objects.get_or_create(name="doctor")
+        assistant_group, _ = Group.objects.get_or_create(name="assistant")
+        user = User.objects.create_user(username="visit_tester", password="pass")
+        user.groups.add(doctor_group, assistant_group)
+        token = Token.objects.create(user=user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+
         self.patient_data = {
             "name": "Visit Tester",
             "gender": "OTHER",

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -53,7 +53,13 @@ class PatientViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
         reg_nums = self.request.query_params.get("registration_numbers")
         if reg_nums:
-            numbers = [int(n) for n in reg_nums.split(",") if n.isdigit()]
+            numbers = []
+            for n in reg_nums.split(","):
+                if n.isdigit():
+                    try:
+                        numbers.append(int(n))
+                    except (ValueError, OverflowError):
+                        continue
             if numbers:
                 queryset = queryset.filter(registration_number__in=numbers)
             else:

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, status
+from rest_framework import viewsets, status, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from .models import Visit, Patient, Queue, PrescriptionImage
@@ -17,6 +17,7 @@ from django.shortcuts import get_object_or_404
 import logging
 
 from .google_drive import upload_prescription_image
+from .permissions import IsDoctor, IsAssistant
 
 try:
     from googleapiclient.errors import GoogleApiError
@@ -25,32 +26,34 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 class QueueViewSet(viewsets.ReadOnlyModelViewSet):
-    """
-    API endpoint that allows queues to be viewed.
-    Provides `list` and `retrieve` actions.
-    """
+    """API endpoint that allows queues to be viewed."""
 
     queryset = Queue.objects.all().order_by("name")
     serializer_class = QueueSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class PatientViewSet(viewsets.ModelViewSet):
-    """
-    API endpoint that allows patients to be viewed or edited.
-    Provides full CRUD operations.
-    Search functionality is available via /api/patients/search/?q=
-    """
+    """API endpoint that allows patients to be viewed or edited."""
 
     queryset = Patient.objects.all().order_by("registration_number")
     serializer_class = PatientSerializer
-    lookup_field = "registration_number"  # Use registration_number for single patient lookups (/api/patients/{registration_number}/)
+    lookup_field = "registration_number"  # Use registration_number for single patient lookups
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):
+        if self.action == "destroy":
+            permission_classes = [IsDoctor]
+        else:
+            permission_classes = [permissions.IsAuthenticated]
+        return [perm() for perm in permission_classes]
 
     def get_queryset(self):
         """Optionally filter patients by a comma-separated list of registration numbers."""
         queryset = super().get_queryset()
         reg_nums = self.request.query_params.get("registration_numbers")
         if reg_nums:
-            numbers = []
+            numbers = [int(n) for n in reg_nums.split(",") if n.isdigit()]
             if numbers:
                 queryset = queryset.filter(registration_number__in=numbers)
             else:
@@ -92,8 +95,18 @@ class PatientViewSet(viewsets.ModelViewSet):
 
 
 class VisitViewSet(viewsets.ModelViewSet):
-    queryset = Visit.objects.all()  # Default queryset
+    queryset = Visit.objects.all()
     serializer_class = VisitSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):
+        if self.action == "create":
+            permission_classes = [IsAssistant]
+        elif self.action == "done":
+            permission_classes = [IsDoctor]
+        else:
+            permission_classes = [permissions.IsAuthenticated]
+        return [perm() for perm in permission_classes]
 
     def get_queryset(self):
         """
@@ -181,6 +194,7 @@ class PrescriptionImageViewSet(viewsets.ModelViewSet):
     queryset = PrescriptionImage.objects.all().order_by("-created_at")
     serializer_class = PrescriptionImageSerializer
     parser_classes = (MultiPartParser, FormParser)
+    permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/clinicq_backend/clinicq_backend/settings.py
+++ b/clinicq_backend/clinicq_backend/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     'rest_framework',
+    'rest_framework.authtoken',
     'api.apps.ApiConfig', # Or just 'api'
 ]
 
@@ -122,3 +123,13 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
+}

--- a/clinicq_backend/clinicq_backend/urls.py
+++ b/clinicq_backend/clinicq_backend/urls.py
@@ -16,9 +16,11 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import path, include # Import include
+from django.urls import path, include
+from rest_framework.authtoken.views import obtain_auth_token
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path('api/auth/login/', obtain_auth_token),
     path('api/', include('api.urls')),
 ]

--- a/clinicq_frontend/src/App.jsx
+++ b/clinicq_frontend/src/App.jsx
@@ -5,6 +5,7 @@ import DoctorPage from './pages/DoctorPage'; // Placeholder for now
 import PublicDisplayPage from './pages/PublicDisplayPage'; // Placeholder for now
 import PatientsPage from './pages/PatientsPage';
 import PatientFormPage from './pages/PatientFormPage';
+import LoginPage from './pages/LoginPage';
 import './App.css'; // Keep or modify as needed
 
 // Placeholder components
@@ -17,6 +18,7 @@ const HomePage = () => (
         <li><Link to="/doctor" className="text-blue-500 hover:underline">Doctor Dashboard</Link></li>
         <li><Link to="/display" className="text-blue-500 hover:underline">Public Queue Display</Link></li>
         <li><Link to="/patients" className="text-blue-500 hover:underline">Manage Patients</Link></li>
+        <li><Link to="/login" className="text-blue-500 hover:underline">Login</Link></li>
       </ul>
     </nav>
   </div>
@@ -41,6 +43,7 @@ function App() {
         <Route path="/patients" element={<PatientsPage />} />
         <Route path="/patients/new" element={<PatientFormPage />} />
         <Route path="/patients/:registration_number/edit" element={<PatientFormPage />} />
+        <Route path="/login" element={<LoginPage />} />
       </Routes>
     </div>
     // </Router> component removed

--- a/clinicq_frontend/src/App.test.jsx
+++ b/clinicq_frontend/src/App.test.jsx
@@ -7,15 +7,15 @@ import App from './App';
 import AssistantPage from './pages/AssistantPage';
 import DoctorPage from './pages/DoctorPage';
 import PublicDisplayPage from './pages/PublicDisplayPage';
-import axios from 'axios';
+import api from './api';
 
-jest.mock('axios');
+jest.mock('./api');
 
 describe('Page Smoke Tests and Basic Accessibility', () => {
   beforeEach(() => {
-    axios.get.mockResolvedValue({ data: [] });
-    axios.post.mockResolvedValue({ data: {} });
-    axios.patch.mockResolvedValue({ data: {} });
+    api.get.mockResolvedValue({ data: [] });
+    api.post.mockResolvedValue({ data: {} });
+    api.patch.mockResolvedValue({ data: {} });
   });
 
   const pages = [
@@ -42,13 +42,13 @@ describe('Page Smoke Tests and Basic Accessibility', () => {
 
 describe('Displays last_5_visit_dates', () => {
   beforeEach(() => {
-    axios.get.mockReset();
-    axios.post.mockReset();
-    axios.patch.mockReset();
+    api.get.mockReset();
+    api.post.mockReset();
+    api.patch.mockReset();
   });
 
   test('Assistant page shows last visit dates for patient', async () => {
-    axios.get.mockImplementation((url) => {
+    api.get.mockImplementation((url) => {
       if (url === '/api/queues/') {
         return Promise.resolve({ data: [{ id: 1, name: 'General' }] });
       }
@@ -67,7 +67,7 @@ describe('Displays last_5_visit_dates', () => {
       }
       return Promise.resolve({ data: [] });
     });
-    axios.post.mockResolvedValue({ data: { token_number: 5 } });
+    api.post.mockResolvedValue({ data: { token_number: 5 } });
 
     const user = userEvent.setup();
     render(
@@ -92,7 +92,7 @@ describe('Displays last_5_visit_dates', () => {
   });
 
   test('Doctor page shows last visit dates for waiting patients', async () => {
-    axios.get.mockImplementation((url) => {
+    api.get.mockImplementation((url) => {
       if (url === '/api/visits/?status=WAITING') {
         return Promise.resolve({
           data: [

--- a/clinicq_frontend/src/__tests__/AssistantPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/AssistantPage.test.jsx
@@ -1,12 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AssistantPage from '../pages/AssistantPage';
-import axios from 'axios';
+import api from '../api';
 
-jest.mock('axios');
+jest.mock('../api');
 
 test('renders Assistant portal heading', async () => {
-  axios.get.mockResolvedValue({ data: [] });
+  api.get.mockResolvedValue({ data: [] });
   render(
     <MemoryRouter>
       <AssistantPage />

--- a/clinicq_frontend/src/__tests__/DoctorPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/DoctorPage.test.jsx
@@ -1,12 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import DoctorPage from '../pages/DoctorPage';
-import axios from 'axios';
+import api from '../api';
 
-jest.mock('axios');
+jest.mock('../api');
 
 test('renders Doctor dashboard heading', async () => {
-  axios.get.mockResolvedValue({ data: [] });
+  api.get.mockResolvedValue({ data: [] });
   render(
     <MemoryRouter>
       <DoctorPage />

--- a/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
@@ -1,12 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import PublicDisplayPage from '../pages/PublicDisplayPage';
-import axios from 'axios';
+import api from '../api';
 
-jest.mock('axios');
+jest.mock('../api');
 
 test('renders Public Display heading', async () => {
-  axios.get.mockResolvedValue({ data: [] });
+  api.get.mockResolvedValue({ data: [] });
   const { unmount } = render(
     <MemoryRouter>
       <PublicDisplayPage />

--- a/clinicq_frontend/src/api.js
+++ b/clinicq_frontend/src/api.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const api = axios.create();
+
+api.interceptors.request.use((config) => {
+  const token = window.localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Token ${token}`;
+  }
+  return config;
+});
+
+export default api;

--- a/clinicq_frontend/src/pages/AssistantPage.jsx
+++ b/clinicq_frontend/src/pages/AssistantPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { Link } from 'react-router-dom';
 
 const AssistantPage = () => {
@@ -20,7 +20,7 @@ const AssistantPage = () => {
   useEffect(() => {
     const fetchQueues = async () => {
       try {
-        const response = await axios.get('/api/queues/');
+        const response = await api.get('/api/queues/');
         setQueues(response.data || []);
       } catch (err) {
         console.error('Error fetching queues:', err);
@@ -37,14 +37,14 @@ const AssistantPage = () => {
         return;
       }
       try {
-        const searchResp = await axios.get(
+        const searchResp = await api.get(
           `/api/patients/search/?q=${encodeURIComponent(registrationNumber.trim())}`
         );
         if (Array.isArray(searchResp.data) && searchResp.data.length > 0) {
           const regNo = searchResp.data[0].registration_number;
-          const detailResp = await axios.get(`/api/patients/${regNo}/`);
+          const detailResp = await api.get(`/api/patients/${regNo}/`);
           setPatientInfo(detailResp.data);
-          const imgResp = await axios.get(`/api/prescriptions/?patient=${regNo}`);
+          const imgResp = await api.get(`/api/prescriptions/?patient=${regNo}`);
           setExistingImages(imgResp.data || []);
         } else {
           setPatientInfo(null);
@@ -83,7 +83,7 @@ const AssistantPage = () => {
     }
 
     try {
-      const response = await axios.post('/api/visits/', {
+      const response = await api.post('/api/visits/', {
         patient: patientInfo.id,
         queue: selectedQueue,
       });
@@ -138,11 +138,11 @@ const AssistantPage = () => {
       const form = new FormData();
       form.append('visit', visitId);
       form.append('image', selectedImage);
-      await axios.post('/api/prescriptions/', form);
+      await api.post('/api/prescriptions/', form);
       setSelectedImage(null);
       const regNo = patientInfo?.registration_number || savedRegistrationNumber;
       if (regNo) {
-        const imgResp = await axios.get(
+        const imgResp = await api.get(
           `/api/prescriptions/?patient=${regNo}`
         );
         setExistingImages(imgResp.data || []);

--- a/clinicq_frontend/src/pages/DoctorPage.jsx
+++ b/clinicq_frontend/src/pages/DoctorPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { Link } from 'react-router-dom';
 
 const DoctorPage = () => {
@@ -14,7 +14,7 @@ const DoctorPage = () => {
     setError('');
     try {
       const queueParam = selectedQueue ? `&queue=${selectedQueue}` : '';
-      const response = await axios.get(`/api/visits/?status=WAITING${queueParam}`);
+      const response = await api.get(`/api/visits/?status=WAITING${queueParam}`);
       const visits = response.data || [];
 
       // Fetch patient details in batch if possible, otherwise one by one
@@ -25,7 +25,7 @@ const DoctorPage = () => {
 
       if (registrationNumbers.length > 0) {
         try {
-          const patientsResp = await axios.get(
+          const patientsResp = await api.get(
             `/api/patients/?registration_numbers=${registrationNumbers.join(',')}`
           );
           patientsByRegNum = (patientsResp.data || []).reduce((acc, patient) => {
@@ -39,7 +39,7 @@ const DoctorPage = () => {
             await Promise.all(
               missingRegs.map(async (regNum) => {
                 try {
-                  const resp = await axios.get(`/api/patients/${regNum}/`);
+                  const resp = await api.get(`/api/patients/${regNum}/`);
                   patientsByRegNum[regNum] = resp.data;
                 } catch {
                   patientsByRegNum[regNum] = null;
@@ -52,7 +52,7 @@ const DoctorPage = () => {
           await Promise.all(
             registrationNumbers.map(async (regNum) => {
               try {
-                const resp = await axios.get(`/api/patients/${regNum}/`);
+                const resp = await api.get(`/api/patients/${regNum}/`);
                 patientsByRegNum[regNum] = resp.data;
               } catch {
                 patientsByRegNum[regNum] = null;
@@ -71,7 +71,7 @@ const DoctorPage = () => {
         withImages = await Promise.all(
           detailedVisits.map(async (v) => {
             try {
-              const imgResp = await axios.get(`/api/prescriptions/?visit=${v.id}`);
+              const imgResp = await api.get(`/api/prescriptions/?visit=${v.id}`);
               return { ...v, prescription_images: imgResp.data || [] };
             } catch {
               return { ...v, prescription_images: [] };
@@ -93,7 +93,7 @@ const DoctorPage = () => {
     if (process.env.NODE_ENV === 'test') return;
     const fetchQueues = async () => {
       try {
-        const response = await axios.get('/api/queues/');
+        const response = await api.get('/api/queues/');
         setQueues(response.data || []);
       } catch (err) {
         console.error('Error fetching queues:', err);
@@ -108,7 +108,7 @@ const DoctorPage = () => {
 
   const handleMarkDone = async (visitId) => {
     try {
-      await axios.patch(`/api/visits/${visitId}/done/`);
+      await api.patch(`/api/visits/${visitId}/done/`);
       fetchWaitingVisits();
     } catch (err) {
       console.error("Error marking visit as done:", err);

--- a/clinicq_frontend/src/pages/LoginPage.jsx
+++ b/clinicq_frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../api';
+
+const LoginPage = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const response = await api.post('/api/auth/login/', {
+        username,
+        password,
+      });
+      const token = response.data.token;
+      if (token) {
+        window.localStorage.setItem('token', token);
+        navigate('/');
+      } else {
+        setError('No token returned');
+      }
+    } catch (err) {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-6 max-w-md bg-white shadow-md rounded-lg mt-10">
+      <h1 className="text-3xl font-bold mb-6 text-center text-gray-700">Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="username">
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700" htmlFor="password">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+          />
+        </div>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button
+          type="submit"
+          className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        >
+          Login
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/clinicq_frontend/src/pages/LoginPage.jsx
+++ b/clinicq_frontend/src/pages/LoginPage.jsx
@@ -18,7 +18,7 @@ const LoginPage = () => {
       });
       const token = response.data.token;
       if (token) {
-        window.localStorage.setItem('token', token);
+        window.sessionStorage.setItem('token', token);
         navigate('/');
       } else {
         setError('No token returned');

--- a/clinicq_frontend/src/pages/PatientFormPage.jsx
+++ b/clinicq_frontend/src/pages/PatientFormPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 const genders = [
@@ -21,14 +21,14 @@ const PatientFormPage = () => {
   useEffect(() => {
     const fetchPatient = async () => {
       try {
-        const response = await axios.get(`/api/patients/${registration_number}/`);
+        const response = await api.get(`/api/patients/${registration_number}/`);
         setFormData({
           name: response.data.name || '',
           phone: response.data.phone || '',
           gender: response.data.gender || 'OTHER',
           age: response.data.age || '',
         });
-        const imgResp = await axios.get(`/api/prescriptions/?patient=${registration_number}`);
+        const imgResp = await api.get(`/api/prescriptions/?patient=${registration_number}`);
         setImages(imgResp.data || []);
       } catch (err) {
         console.error('Failed to load patient', err);
@@ -50,9 +50,9 @@ const PatientFormPage = () => {
     setError('');
     try {
       if (isEdit) {
-        await axios.put(`/api/patients/${registration_number}/`, formData);
+        await api.put(`/api/patients/${registration_number}/`, formData);
       } else {
-        await axios.post('/api/patients/', formData);
+        await api.post('/api/patients/', formData);
       }
       navigate('/patients');
     } catch (err) {

--- a/clinicq_frontend/src/pages/PatientsPage.jsx
+++ b/clinicq_frontend/src/pages/PatientsPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { Link, useNavigate } from 'react-router-dom';
 
 const PatientsPage = () => {
@@ -17,7 +17,7 @@ const PatientsPage = () => {
       if (term.trim()) {
         url = `/api/patients/search/?q=${encodeURIComponent(term.trim())}`;
       }
-      const response = await axios.get(url);
+      const response = await api.get(url);
       setPatients(response.data);
     } catch (err) {
       console.error('Failed to fetch patients', err);
@@ -34,7 +34,7 @@ const PatientsPage = () => {
   const handleDelete = async (regNum) => {
     if (!window.confirm('Are you sure you want to delete this patient?')) return;
     try {
-      await axios.delete(`/api/patients/${regNum}/`);
+      await api.delete(`/api/patients/${regNum}/`);
       setPatients((prev) => prev.filter((p) => p.registration_number !== regNum));
     } catch (err) {
       console.error('Delete failed', err);

--- a/clinicq_frontend/src/pages/PublicDisplayPage.jsx
+++ b/clinicq_frontend/src/pages/PublicDisplayPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import axios from 'axios';
+import api from '../api';
 import { Link } from 'react-router-dom';
 
 const REFRESH_INTERVAL = 5000; // 5 seconds
@@ -17,7 +17,7 @@ const PublicDisplayPage = ({ initialQueue = '' }) => {
       setError('');
       try {
         const queueParam = selectedQueue ? `&queue=${selectedQueue}` : '';
-        const response = await axios.get(`/api/visits/?status=WAITING${queueParam}`);
+        const response = await api.get(`/api/visits/?status=WAITING${queueParam}`);
         setWaitingVisits(response.data || []);
       } catch (err) {
         console.error("Error fetching waiting visits:", err);
@@ -38,7 +38,7 @@ const PublicDisplayPage = ({ initialQueue = '' }) => {
   useEffect(() => {
     const fetchQueues = async () => {
       try {
-        const response = await axios.get('/api/queues/');
+        const response = await api.get('/api/queues/');
         setQueues(response.data || []);
       } catch (err) {
         console.error('Error fetching queues:', err);


### PR DESCRIPTION
## Summary
- Add token-based authentication and role permissions for doctors and assistants
- Protect API endpoints and expose login endpoint
- Add frontend login workflow and shared API client with token header

## Testing
- `cd clinicq_backend && DJANGO_SETTINGS_MODULE=clinicq_backend.settings pytest`
- `cd clinicq_frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4fcd782a08323a202cb8668616f26