### PR TITLE
Clean up backend for flake8 compliance

### DIFF
--- a/clinicq_backend/api/admin.py
+++ b/clinicq_backend/api/admin.py
@@ -1,10 +1,18 @@
 from django.contrib import admin
 from .models import Visit
 
+
 @admin.register(Visit)
 class VisitAdmin(admin.ModelAdmin):
-    list_display = ('token_number', 'patient', 'queue', 'visit_date', 'status', 'created_at')
-    list_filter = ('status', 'visit_date', 'queue')
-    search_fields = ('patient__name', 'token_number')
-    date_hierarchy = 'visit_date'
-    ordering = ('-visit_date', 'token_number')
+    list_display = (
+        "token_number",
+        "patient",
+        "queue",
+        "visit_date",
+        "status",
+        "created_at",
+    )
+    list_filter = ("status", "visit_date", "queue")
+    search_fields = ("patient__name", "token_number")
+    date_hierarchy = "visit_date"
+    ordering = ("-visit_date", "token_number")

--- a/clinicq_backend/api/google_drive.py
+++ b/clinicq_backend/api/google_drive.py
@@ -20,7 +20,10 @@ def upload_prescription_image(file_obj):
     )
     service = build('drive', 'v3', credentials=creds)
     file_metadata = {'name': file_obj.name}
-    media = MediaIoBaseUpload(io.BytesIO(file_obj.read()), mimetype=file_obj.content_type)
+    media = MediaIoBaseUpload(
+        io.BytesIO(file_obj.read()),
+        mimetype=file_obj.content_type,
+    )
     created = (
         service.files()
         .create(body=file_metadata, media_body=media, fields='id, webViewLink')

--- a/clinicq_backend/api/models.py
+++ b/clinicq_backend/api/models.py
@@ -1,6 +1,6 @@
 from django.db import models
-from django.utils import timezone
 import datetime
+
 
 class Visit(models.Model):
     PATIENT_GENDER_CHOICES = [
@@ -21,32 +21,49 @@ class Visit(models.Model):
         choices=STATUS_CHOICES,
         default='WAITING',
     )
-    patient = models.ForeignKey('Patient', on_delete=models.CASCADE, related_name='visits')
-    queue = models.ForeignKey('Queue', on_delete=models.CASCADE, related_name='visits')
+    patient = models.ForeignKey(
+        "Patient",
+        on_delete=models.CASCADE,
+        related_name="visits",
+    )
+    queue = models.ForeignKey(
+        "Queue",
+        on_delete=models.CASCADE,
+        related_name="visits",
+    )
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
         # Update unique_together to include queue
-        # The old unique_together ('token_number', 'visit_date') will be removed by makemigrations.
-        unique_together = ('token_number', 'visit_date', 'queue')
-        ordering = ['visit_date', 'queue', 'token_number']
+        # The old unique_together ('token_number', 'visit_date')
+        # will be removed by makemigrations.
+        unique_together = ("token_number", "visit_date", "queue")
+        ordering = ["visit_date", "queue", "token_number"]
 
     def __str__(self):
-        return f"Token {self.token_number} - {self.patient.name} ({self.visit_date})"
+        return (
+            f"Token {self.token_number} - {self.patient.name}"
+            f" ({self.visit_date})"
+        )
 
 
 class Patient(models.Model):
-    # Using AutoField for registration_number to ensure uniqueness and simplicity for now.
-    # This could be changed to a custom CharField with validation if specific formats are needed.
+    # Using AutoField for registration_number to ensure uniqueness and
+    # simplicity for now. This could be changed to a custom CharField with
+    # validation if specific formats are needed.
     registration_number = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255)
-    phone = models.CharField(max_length=20, blank=True, null=True) # Assuming phone is optional
+    phone = models.CharField(
+        max_length=20,
+        blank=True,
+        null=True,
+    )  # Assuming phone is optional
     gender = models.CharField(
         max_length=10,
-        choices=Visit.PATIENT_GENDER_CHOICES, # Reusing choices from Visit
-        default='OTHER',
+        choices=Visit.PATIENT_GENDER_CHOICES,  # Reusing choices from Visit
+        default="OTHER",
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -56,10 +73,11 @@ class Patient(models.Model):
 
     class Meta:
         indexes = [
-            models.Index(fields=['phone']),
+            models.Index(fields=["phone"]),
             # registration_number is already indexed as it's a primary key.
-            # Adding an explicit index for name if frequent partial searches are expected.
-            models.Index(fields=['name']),
+            # Adding an explicit index for name if frequent partial searches
+            # are expected.
+            models.Index(fields=["name"]),
         ]
 
 

--- a/clinicq_backend/api/permissions.py
+++ b/clinicq_backend/api/permissions.py
@@ -1,5 +1,6 @@
 from rest_framework import permissions
 
+
 class IsDoctor(permissions.BasePermission):
     """Allows access only to users in the 'doctor' group."""
 

--- a/clinicq_backend/api/serializers.py
+++ b/clinicq_backend/api/serializers.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 from .models import Visit, Patient, Queue, PrescriptionImage
-from django.utils import timezone
-import datetime
+
 
 class PatientSerializer(serializers.ModelSerializer):
     last_5_visit_dates = serializers.SerializerMethodField()
@@ -15,7 +14,11 @@ class PatientSerializer(serializers.ModelSerializer):
         read_only_fields = ['registration_number', 'created_at', 'updated_at']
 
     def get_last_5_visit_dates(self, obj):
-        return obj.visits.order_by('-visit_date').values_list('visit_date', flat=True)[:5]
+        return (
+            obj.visits.order_by("-visit_date")
+            .values_list("visit_date", flat=True)[:5]
+        )
+
 
 class QueueSerializer(serializers.ModelSerializer):
     class Meta:
@@ -23,39 +26,57 @@ class QueueSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'created_at', 'updated_at']
         read_only_fields = ['id', 'created_at', 'updated_at']
 
+
 class VisitSerializer(serializers.ModelSerializer):
     # Read-only fields for displaying related data
-    patient_registration_number = serializers.CharField(source='patient.registration_number', read_only=True)
-    patient_full_name = serializers.CharField(source='patient.name', read_only=True)
-    queue_name = serializers.CharField(source='queue.name', read_only=True)
+    patient_registration_number = serializers.CharField(
+        source="patient.registration_number",
+        read_only=True,
+    )
+    patient_full_name = serializers.CharField(
+        source="patient.name",
+        read_only=True,
+    )
+    queue_name = serializers.CharField(
+        source="queue.name",
+        read_only=True,
+    )
 
     # Writeable fields for linking to Patient and Queue
     # The client will send 'patient' (registration_number) and 'queue' (id).
     patient = serializers.PrimaryKeyRelatedField(
         queryset=Patient.objects.all(),
-        required=True # A visit must be associated with a patient.
+        required=True,  # A visit must be associated with a patient.
     )
     queue = serializers.PrimaryKeyRelatedField(
         queryset=Queue.objects.all(),
-        required=True # A visit must be associated with a queue.
+        required=True,  # A visit must be associated with a queue.
     )
 
     class Meta:
         model = Visit
         fields = [
-            'id', 'token_number',
-            'visit_date', 'status',
-            'created_at', 'updated_at', # model's updated_at
-            'patient', # write-only FK to Patient model (expects Patient PK)
-            'queue',   # write-only FK to Queue model (expects Queue PK)
-            'patient_registration_number', # read-only representation
-            'patient_full_name', # read-only representation
-            'queue_name', # read-only representation
+            "id",
+            "token_number",
+            "visit_date",
+            "status",
+            "created_at",
+            "updated_at",  # model's updated_at
+            "patient",  # write-only FK to Patient model (expects Patient PK)
+            "queue",  # write-only FK to Queue model (expects Queue PK)
+            "patient_registration_number",  # read-only representation
+            "patient_full_name",  # read-only representation
+            "queue_name",  # read-only representation
         ]
         read_only_fields = [
-            'token_number', 'visit_date', 'status',
-            'created_at', 'updated_at',
-            'patient_registration_number', 'patient_full_name', 'queue_name',
+            "token_number",
+            "visit_date",
+            "status",
+            "created_at",
+            "updated_at",
+            "patient_registration_number",
+            "patient_full_name",
+            "queue_name",
         ]
 
     # The token generation logic from the old VisitSerializer.create method
@@ -65,6 +86,7 @@ class VisitSerializer(serializers.ModelSerializer):
     #     ... logic moved to ViewSet ...
     #     return Visit.objects.create(**validated_data)
 
+
 class VisitStatusUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Visit
@@ -72,7 +94,9 @@ class VisitStatusUpdateSerializer(serializers.ModelSerializer):
 
     def validate_status(self, value):
         if value != 'DONE':
-            raise serializers.ValidationError("This endpoint only allows updating status to 'DONE'.")
+            raise serializers.ValidationError(
+                "This endpoint only allows updating status to 'DONE'."
+            )
         return value
 
 

--- a/clinicq_backend/api/urls.py
+++ b/clinicq_backend/api/urls.py
@@ -8,13 +8,19 @@ from .views import (
 )
 
 router = DefaultRouter()
-router.register(r'visits', VisitViewSet, basename='visit')
-router.register(r'patients', PatientViewSet, basename='patient') # Added patient route
-router.register(r'queues', QueueViewSet, basename='queue') # Added queue route
-router.register(r'prescriptions', PrescriptionImageViewSet, basename='prescription')
+router.register(r"visits", VisitViewSet, basename="visit")
+# Added patient route
+router.register(r"patients", PatientViewSet, basename="patient")
+# Added queue route
+router.register(r"queues", QueueViewSet, basename="queue")
+router.register(
+    r"prescriptions",
+    PrescriptionImageViewSet,
+    basename="prescription",
+)
 
 urlpatterns = [
-    path('', include(router.urls)),
-    # The patient search endpoint is registered as an action within PatientViewSet
-    # so it will be available at /api/patients/search/
+    path("", include(router.urls)),
+    # The patient search endpoint is registered as an action within
+    # PatientViewSet so it will be available at /api/patients/search/
 ]


### PR DESCRIPTION
## Summary
- refactor views and logging, split long comments and fix patient filter logic
- tidy backend modules by removing unused imports and formatting for flake8

## Testing
- `flake8 clinicq_backend/api/admin.py clinicq_backend/api/google_drive.py clinicq_backend/api/models.py clinicq_backend/api/permissions.py clinicq_backend/api/serializers.py clinicq_backend/api/urls.py clinicq_backend/api/views.py`

------
https://chatgpt.com/codex/tasks/task_e_68a51e50001883238f02e6395d8c3cc5