### PR TITLE
feat(frontend): use import.meta env for environment checks

### DIFF
--- a/clinicq_frontend/babel.config.js
+++ b/clinicq_frontend/babel.config.js
@@ -3,4 +3,5 @@ export default {
     ['@babel/preset-env', { targets: { node: 'current' } }],
     ['@babel/preset-react', { runtime: 'automatic' }],
   ],
+  plugins: ['babel-plugin-transform-vite-meta-env'],
 };

--- a/clinicq_frontend/jest.setup.js
+++ b/clinicq_frontend/jest.setup.js
@@ -2,6 +2,8 @@
 import '@testing-library/jest-dom'; // For expect(...).toBeInTheDocument() etc.
 import 'whatwg-fetch'; // Polyfill for fetch
 
+// Ensure Vite-style environment variables are available in tests
+process.env.MODE = process.env.MODE || 'test';
 // Polyfill for TextEncoder
 // Node.js 'util' module should be available in Jest's Node environment
 const util = require('util');

--- a/clinicq_frontend/package-lock.json
+++ b/clinicq_frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@vitejs/plugin-react": "^4.5.2",
         "autoprefixer": "^10.4.21",
         "babel-jest": "^30.0.4",
+        "babel-plugin-transform-vite-meta-env": "^1.0.3",
         "broadcast-channel": "^7.1.0",
         "cross-env": "^7.0.3",
         "eslint": "^9.29.0",
@@ -4725,6 +4726,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-vite-meta-env": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vite-meta-env/-/babel-plugin-transform-vite-meta-env-1.0.3.tgz",
+      "integrity": "sha512-eyfuDEXrMu667TQpmctHeTlJrZA6jXYHyEJFjcM0yEa60LS/LXlOg2PBbMb8DVS+V9CnTj/j9itdlDVMcY2zEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {

--- a/clinicq_frontend/package.json
+++ b/clinicq_frontend/package.json
@@ -28,6 +28,7 @@
     "@vitejs/plugin-react": "^4.5.2",
     "autoprefixer": "^10.4.21",
     "babel-jest": "^30.0.4",
+    "babel-plugin-transform-vite-meta-env": "^1.0.3",
     "broadcast-channel": "^7.1.0",
     "cross-env": "^7.0.3",
     "eslint": "^9.29.0",

--- a/clinicq_frontend/src/pages/DoctorPage.jsx
+++ b/clinicq_frontend/src/pages/DoctorPage.jsx
@@ -67,7 +67,7 @@ const DoctorPage = () => {
         patient_details: patientsByRegNum[visit.patient_registration_number] || null,
       }));
       let withImages = detailedVisits;
-      if (process.env.NODE_ENV !== 'test') {
+      if (import.meta.env.MODE !== 'test') {
         withImages = await Promise.all(
           detailedVisits.map(async (v) => {
             try {
@@ -89,8 +89,8 @@ const DoctorPage = () => {
     }
   }, [selectedQueue]);
 
-  useEffect(() => {
-    if (process.env.NODE_ENV === 'test') return;
+    useEffect(() => {
+      if (import.meta.env.MODE === 'test') return;
     const fetchQueues = async () => {
       try {
         const response = await api.get('/api/queues/');


### PR DESCRIPTION
## Summary
- refactor DoctorPage to use `import.meta.env.MODE` instead of `process.env.NODE_ENV`
- add Babel plugin and test setup to support `import.meta.env` in Jest

## Testing
- `cd clinicq_frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a51e5509f083238a804ce4b8ae372b