### PR TITLE
chore: remove unused React imports

### DIFF
--- a/clinicq_frontend/src/App.jsx
+++ b/clinicq_frontend/src/App.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Routes, Route, Link, useSearchParams } from 'react-router-dom'; // Removed BrowserRouter as Router
 import AssistantPage from './pages/AssistantPage';
 import DoctorPage from './pages/DoctorPage'; // Placeholder for now

--- a/clinicq_frontend/src/App.test.jsx
+++ b/clinicq_frontend/src/App.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';

--- a/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
@@ -7,7 +7,7 @@ jest.mock('../api');
 
 test('renders Public Display heading', async () => {
   api.get.mockResolvedValue({ data: [] });
-  const { unmount } = render(
+  render(
     <MemoryRouter>
       <PublicDisplayPage />
     </MemoryRouter>

--- a/clinicq_frontend/src/pages/AssistantPage.jsx
+++ b/clinicq_frontend/src/pages/AssistantPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import api from '../api';
 import { Link } from 'react-router-dom';
 

--- a/clinicq_frontend/src/pages/DoctorPage.jsx
+++ b/clinicq_frontend/src/pages/DoctorPage.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useCallback } from 'react';
+/* global process */
+import { useState, useEffect, useCallback } from 'react';
 import api from '../api';
 import { Link } from 'react-router-dom';
 

--- a/clinicq_frontend/src/pages/LoginPage.jsx
+++ b/clinicq_frontend/src/pages/LoginPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../api';
 
@@ -23,7 +23,7 @@ const LoginPage = () => {
       } else {
         setError('No token returned');
       }
-    } catch (err) {
+    } catch {
       setError('Invalid credentials');
     }
   };

--- a/clinicq_frontend/src/pages/PatientFormPage.jsx
+++ b/clinicq_frontend/src/pages/PatientFormPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import api from '../api';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 

--- a/clinicq_frontend/src/pages/PatientsPage.jsx
+++ b/clinicq_frontend/src/pages/PatientsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import api from '../api';
 import { Link, useNavigate } from 'react-router-dom';
 

--- a/clinicq_frontend/src/pages/PublicDisplayPage.jsx
+++ b/clinicq_frontend/src/pages/PublicDisplayPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import api from '../api';
 import { Link } from 'react-router-dom';
 


### PR DESCRIPTION
## Summary
- drop unnecessary default React imports across app pages and tests
- clean up linter warnings including unused variables
- ensure process global defined for DoctorPage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a51e5580bc8323a45ef9b23c919287