### PR TITLE
Handle patient filtering by registration numbers

### DIFF
--- a/clinicq_backend/api/test_api.py
+++ b/clinicq_backend/api/test_api.py
@@ -69,6 +69,29 @@ class PatientAPITests(APITestCase):
             self.patient2.registration_number,
         }
 
+    def test_get_patients_by_mixed_registration_numbers(self):
+        url = reverse("patient-list")
+        query = (
+            f"{self.patient1.registration_number}, abc ,{self.patient2.registration_number},xyz"
+        )
+        response = self.client.get(url, {"registration_numbers": query}, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        numbers = [p["registration_number"] for p in response.data]
+        assert numbers == [
+            self.patient1.registration_number,
+            self.patient2.registration_number,
+        ]
+
+    def test_get_patients_by_invalid_registration_numbers(self):
+        url = reverse("patient-list")
+        response = self.client.get(
+            url,
+            {"registration_numbers": "abc, xyz"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
+
     def test_get_patient_detail(self):
         url = reverse(
             "patient-detail",

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -53,7 +53,11 @@ class PatientViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
         reg_nums = self.request.query_params.get("registration_numbers")
         if reg_nums:
-            numbers = [int(n.strip()) for n in reg_nums.split(",") if n.strip().isdigit()]
+            numbers = []
+            for num in reg_nums.split(","):
+                num = num.strip()
+                if num.isdigit():
+                    numbers.append(int(num))
             if numbers:
                 queryset = queryset.filter(registration_number__in=numbers)
             else:


### PR DESCRIPTION
## Summary
- parse `registration_numbers` parameter into numeric list and filter patients
- test registration number parsing for valid, mixed, and invalid inputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a52ff9af4c83238f66bccd0a362daf