### PR TITLE
Add CI workflow for backend and frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r clinicq_backend/requirements.txt
+          pip install -r clinicq_backend/requirements-dev.txt
+
+      - name: Lint backend with flake8
+        run: flake8 .
+        working-directory: clinicq_backend
+
+      - name: Run backend tests
+        run: pytest
+        working-directory: clinicq_backend
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install frontend dependencies
+        run: npm ci --prefer-offline --no-audit --progress=false
+        working-directory: clinicq_frontend
+
+      - name: Lint frontend with ESLint
+        run: npm run lint
+        working-directory: clinicq_frontend
+
+      - name: Run frontend tests
+        run: npm test -- --watchAll=false
+        working-directory: clinicq_frontend


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint and test backend and frontend

## Testing
- `flake8 .` *(fails: undefined name 'numbers', syntax error, etc.)*
- `pytest` *(fails: SyntaxError in settings.py)*
- `npm run lint` *(fails: 'process' is defined but never used in DoctorPage.jsx)*
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a5335c6b788323ab4b4cc78345d639