### PR TITLE
docs: expand setup instructions and add API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,30 @@ Follow these steps to run ClinicQ locally for development and testing.
    * **Backend API** – [http://localhost:8000/api/](http://localhost:8000/api/)
    * **Django admin** – [http://localhost:8000/admin/](http://localhost:8000/admin/) (log in using the superuser credentials from step 2)
 
+### Manual Setup (without Docker)
+
+If you prefer running the stack without Docker, ensure PostgreSQL is running and then:
+
+1. **Backend**
+   ```bash
+   python -m venv .venv && source .venv/bin/activate
+   pip install -r clinicq_backend/requirements.txt
+   export DATABASE_URL=postgresql://<user>:<password>@localhost:5432/<db>
+   cd clinicq_backend
+   python manage.py migrate
+   python manage.py runserver
+   ```
+2. **Frontend**
+   ```bash
+   cd ../clinicq_frontend
+   npm install
+   npm run dev
+   ```
+   The Vite dev server will be available at `http://localhost:5173`.
+
 ### Environment Variables
 
-Default development values are provided via `docker-compose.yml`. Override them in a `.env` file or your shell as needed.
+Default development values are provided via `docker-compose.yml`. Create a `.env` file or export variables in your shell to override them when running locally.
 
 | Variable | Service | Description | Default |
 | --- | --- | --- | --- |
@@ -103,6 +124,8 @@ Default development values are provided via `docker-compose.yml`. Override them 
 | `DJANGO_SUPERUSER_EMAIL` | backend | Initial superuser email | `admin@example.com` |
 | `DJANGO_SUPERUSER_PASSWORD` | backend | Initial superuser password | `adminpass` |
 | `VITE_API_BASE_URL` | frontend | URL used by frontend to reach the API | `http://localhost:8000/api` |
+| `CHOKIDAR_USEPOLLING` | frontend | Enables file-watching in some Docker setups | `true` |
+| `WDS_SOCKET_PORT` | frontend | Port used for Vite's HMR websocket | `5173` |
 
 ### Creating Additional Admin Users
 
@@ -193,7 +216,7 @@ docker-compose exec frontend npm test -- --watchAll=false
 
 ## API Documentation
 
-Once the backend is running, the Django REST Framework browsable API is available at [http://localhost:8000/api/](http://localhost:8000/api/). Use it to explore and interact with endpoints during development.
+Detailed endpoint information is available in [docs/api.md](docs/api.md). Once the backend is running, the Django REST Framework browsable API is available at [http://localhost:8000/api/](http://localhost:8000/api/).
 
 ## Contributing
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,25 @@
+# ClinicQ API Overview
+
+The ClinicQ backend exposes a RESTful API under the `/api/` prefix.
+The following endpoints are useful during development. Replace `<id>` or `<reg_no>`
+with the appropriate identifiers.
+
+## Patients
+- `GET /api/patients/` – List patients
+- `POST /api/patients/` – Create a patient
+- `GET /api/patients/<reg_no>/` – Retrieve a patient by registration number
+- `PUT /api/patients/<reg_no>/` – Replace a patient record
+- `PATCH /api/patients/<reg_no>/` – Partially update a patient record
+- `DELETE /api/patients/<reg_no>/` – Remove a patient
+- `GET /api/patients/search/?q=<query>` – Search patients by registration number, name, or phone
+
+## Visits
+- `POST /api/visits/` – Create a new visit (token)
+- `GET /api/visits/?status=WAITING[&queue=<id>]` – List waiting visits, optionally filtered by queue
+- `PATCH /api/visits/<id>/done/` – Mark a visit as done
+
+## Queues
+- `GET /api/queues/` – List available service queues
+
+For a browsable interface, start the backend and navigate to
+`http://localhost:8000/api/` in your browser.


### PR DESCRIPTION
## Summary
- add manual setup instructions for backend and frontend
- document key env vars and link to API reference

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django_test_migrations')*
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a5335ef414832394ac751f91209484