### PR TITLE
Implement authentication and secure access

### DIFF
--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -57,7 +57,11 @@ class PatientViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
         reg_nums = self.request.query_params.get("registration_numbers")
         if reg_nums:
-
+            numbers = [
+                int(num.strip())
+                for num in reg_nums.split(",")
+                if num.strip().isdigit()
+            ]
             if numbers:
                 queryset = queryset.filter(
                     registration_number__in=numbers
@@ -208,6 +212,13 @@ class PrescriptionImageViewSet(viewsets.ModelViewSet):
     serializer_class = PrescriptionImageSerializer
     parser_classes = (MultiPartParser, FormParser)
     permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):
+        if self.action in ["create", "update", "partial_update", "destroy"]:
+            permission_classes = [IsDoctor]
+        else:
+            permission_classes = [permissions.IsAuthenticated]
+        return [perm() for perm in permission_classes]
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/clinicq_backend/clinicq_backend/settings.py
+++ b/clinicq_backend/clinicq_backend/settings.py
@@ -132,7 +132,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "json": {
-            "()": "pythonjsonlogger.JsonFormatter",
+            "()": "pythonjsonlogger.jsonlogger.JsonFormatter",
             "fmt": "%(asctime)s %(levelname)s %(name)s %(message)s",
         },
     },
@@ -146,6 +146,9 @@ LOGGING = {
         "handlers": ["console"],
         "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
     },
+}
+
+
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication",
@@ -154,5 +157,4 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
     ],
-
 }

--- a/clinicq_frontend/src/pages/LoginPage.jsx
+++ b/clinicq_frontend/src/pages/LoginPage.jsx
@@ -18,7 +18,7 @@ const LoginPage = () => {
       });
       const token = response.data.token;
       if (token) {
-        window.sessionStorage.setItem('token', token);
+        window.localStorage.setItem('token', token);
         navigate('/');
       } else {
         setError('No token returned');


### PR DESCRIPTION
## Summary
- fix REST framework settings and logging configuration
- restrict prescription image modifications to doctors
- store auth token in browser storage on login

## Testing
- `pytest clinicq_backend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a53360d6188323a965c34a8f12fe42