### PR TITLE
feat: add structured logging and client error reporting

### DIFF
--- a/clinicq_backend/clinicq_backend/settings.py
+++ b/clinicq_backend/clinicq_backend/settings.py
@@ -132,7 +132,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "json": {
-            "()": "pythonjsonlogger.JsonFormatter",
+            "()": "pythonjsonlogger.jsonlogger.JsonFormatter",
             "fmt": "%(asctime)s %(levelname)s %(name)s %(message)s",
         },
     },
@@ -146,6 +146,8 @@ LOGGING = {
         "handlers": ["console"],
         "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
     },
+}
+
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication",

--- a/clinicq_frontend/src/ErrorBoundary.jsx
+++ b/clinicq_frontend/src/ErrorBoundary.jsx
@@ -1,0 +1,61 @@
+import { Component } from 'react'
+import * as Sentry from '@sentry/react'
+
+/**
+ * A React error boundary that reports errors to a monitoring service.
+ *
+ * If `VITE_SENTRY_DSN` is defined, errors are captured using Sentry. In
+ * addition, if `VITE_LOG_ENDPOINT` is set, a POST request containing the error
+ * and component stack is sent to that endpoint. This makes the monitoring
+ * destination configurable via environment variables.
+ */
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    if (import.meta.env.VITE_SENTRY_DSN) {
+      Sentry.captureException(error, { extra: errorInfo })
+    }
+
+    const endpoint = import.meta.env.VITE_LOG_ENDPOINT
+    if (endpoint) {
+      fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          error: error.toString(),
+          componentStack: errorInfo.componentStack,
+        }),
+      }).catch(() => {
+        /* Swallow network errors to avoid cascading failures */
+      })
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <div>
+            <p>
+              Something went wrong. Please try refreshing the page. If the
+              problem persists, contact support.
+            </p>
+          </div>
+        )
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary
+

--- a/clinicq_frontend/src/main.jsx
+++ b/clinicq_frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import * as Sentry from '@sentry/react'
 import './index.css'
 import App from './App.jsx'
+import ErrorBoundary from './ErrorBoundary.jsx'
 
 if (import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({ dsn: import.meta.env.VITE_SENTRY_DSN })
@@ -11,14 +12,10 @@ if (import.meta.env.VITE_SENTRY_DSN) {
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <Sentry.ErrorBoundary fallback={
-      <div>
-        <p>Something went wrong. Please try refreshing the page. If the problem persists, contact support.</p>
-      </div>
-    }>
+    <ErrorBoundary>
       <BrowserRouter>
         <App />
       </BrowserRouter>
-    </Sentry.ErrorBoundary>
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- configure Django to emit structured JSON logs
- add React error boundary that forwards errors to Sentry or a custom endpoint

## Testing
- `pytest api/test_api.py::PatientAPITests::test_get_patients_by_registration_numbers -q 2>&1 | tail -n 20`
- `cd clinicq_frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a53361cf50832395f39d5d17a3ff60