### PR TITLE
Add pagination and caching to patient and visit APIs

### DIFF
--- a/clinicq_backend/api/pagination.py
+++ b/clinicq_backend/api/pagination.py
@@ -1,0 +1,9 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class StandardResultsSetPagination(PageNumberPagination):
+    """Default pagination settings for API viewsets."""
+
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 100

--- a/clinicq_backend/api/test_api.py
+++ b/clinicq_backend/api/test_api.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from django.contrib.auth.models import User, Group
 from rest_framework.authtoken.models import Token
+from django.core.cache import cache
 from .models import Visit, Patient, Queue
 from django.utils import timezone
 from datetime import date, timedelta
@@ -13,6 +14,7 @@ from freezegun import freeze_time
 @pytest.mark.django_db
 class PatientAPITests(APITestCase):
     def setUp(self):
+        cache.clear()
         doctor_group, _ = Group.objects.get_or_create(name="doctor")
         assistant_group, _ = Group.objects.get_or_create(name="assistant")
         user = User.objects.create_user(username="tester", password="pass")
@@ -50,9 +52,8 @@ class PatientAPITests(APITestCase):
         url = reverse("patient-list")
         response = self.client.get(url, format="json")
         assert response.status_code == status.HTTP_200_OK
-        assert (
-            len(response.data) == 2
-        )  # Assuming default pagination is not too small or using TestClient default
+        assert response.data["count"] == 2
+        assert len(response.data["results"]) == 2
 
     def test_get_patients_by_registration_numbers(self):
         url = reverse("patient-list")
@@ -63,7 +64,7 @@ class PatientAPITests(APITestCase):
             format="json",
         )
         assert response.status_code == status.HTTP_200_OK
-        returned = {p["registration_number"] for p in response.data}
+        returned = {p["registration_number"] for p in response.data["results"]}
         assert returned == {
             self.patient1.registration_number,
             self.patient2.registration_number,
@@ -109,28 +110,28 @@ class PatientAPITests(APITestCase):
             url, {"q": str(self.patient1.registration_number)}, format="json"
         )
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 1
-        assert response.data[0]["name"] == self.patient1.name
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["name"] == self.patient1.name
 
     def test_search_patient_by_name_fragment(self):
         url = reverse("patient-search")
         response = self.client.get(url, {"q": "Alice"}, format="json")  # Partial name
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 1
-        assert response.data[0]["name"] == self.patient1.name
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["name"] == self.patient1.name
 
     def test_search_patient_by_phone_fragment(self):
         url = reverse("patient-search")
         response = self.client.get(url, {"q": "12345"}, format="json")  # Partial phone
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 1
-        assert response.data[0]["name"] == self.patient1.name
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["name"] == self.patient1.name
 
     def test_search_patient_no_results(self):
         url = reverse("patient-search")
         response = self.client.get(url, {"q": "NonExistent"}, format="json")
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 0
+        assert response.data["count"] == 0
 
     def test_search_patient_missing_query_param(self):
         url = reverse("patient-search")
@@ -170,6 +171,7 @@ class PatientAPITests(APITestCase):
 @pytest.mark.django_db
 class QueueAPITests(APITestCase):
     def setUp(self):
+        cache.clear()
         doctor_group, _ = Group.objects.get_or_create(name="doctor")
         assistant_group, _ = Group.objects.get_or_create(name="assistant")
         user = User.objects.create_user(username="queue_tester", password="pass")
@@ -199,6 +201,7 @@ class QueueAPITests(APITestCase):
 @pytest.mark.django_db
 class VisitAPITests(APITestCase):
     def setUp(self):
+        cache.clear()
         doctor_group, _ = Group.objects.get_or_create(name="doctor")
         assistant_group, _ = Group.objects.get_or_create(name="assistant")
         user = User.objects.create_user(username="visit_tester", password="pass")
@@ -317,22 +320,22 @@ class VisitAPITests(APITestCase):
         url_q1 = reverse("visit-list") + f"?status=WAITING&queue={self.queue1.pk}"
         response_q1 = self.client.get(url_q1, format="json")
         assert response_q1.status_code == status.HTTP_200_OK
-        assert len(response_q1.data) == 1
-        assert response_q1.data[0]["patient_full_name"] == self.patient.name
-        assert response_q1.data[0]["queue_name"] == self.queue1.name
+        assert response_q1.data["count"] == 1
+        assert response_q1.data["results"][0]["patient_full_name"] == self.patient.name
+        assert response_q1.data["results"][0]["queue_name"] == self.queue1.name
 
         url_q2 = reverse("visit-list") + f"?status=WAITING&queue={self.queue2.pk}"
         response_q2 = self.client.get(url_q2, format="json")
         assert response_q2.status_code == status.HTTP_200_OK
-        assert len(response_q2.data) == 1
-        assert response_q2.data[0]["patient_full_name"] == patient2.name
-        assert response_q2.data[0]["queue_name"] == self.queue2.name
+        assert response_q2.data["count"] == 1
+        assert response_q2.data["results"][0]["patient_full_name"] == patient2.name
+        assert response_q2.data["results"][0]["queue_name"] == self.queue2.name
 
         # Test without queue filter, should show all waiting for today
         url_all_waiting = reverse("visit-list") + "?status=WAITING"
         response_all_waiting = self.client.get(url_all_waiting, format="json")
         assert response_all_waiting.status_code == status.HTTP_200_OK
-        assert len(response_all_waiting.data) == 2
+        assert response_all_waiting.data["count"] == 2
 
     def test_patch_visit_done_api(self):
         visit = Visit.objects.create(

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -1,6 +1,16 @@
 from rest_framework import viewsets, status, permissions
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework.parsers import MultiPartParser, FormParser
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
+from django.core.cache import cache
+from django.db.models import Q  # For complex lookups (patient search)
+import datetime  # Required for date operations
+import logging
+
 from .models import Visit, Patient, Queue, PrescriptionImage
 from .serializers import (
     VisitSerializer,
@@ -9,12 +19,7 @@ from .serializers import (
     QueueSerializer,
     PrescriptionImageSerializer,
 )
-from django.utils import timezone
-import datetime  # Required for date operations
-from django.db.models import Q  # For complex lookups (patient search)
-from rest_framework.parsers import MultiPartParser, FormParser
-from django.shortcuts import get_object_or_404
-import logging
+from .pagination import StandardResultsSetPagination
 from .google_drive import upload_prescription_image
 from .permissions import IsDoctor, IsAssistant
 
@@ -26,6 +31,8 @@ except Exception:  # pragma: no cover - optional dependency
     GoogleApiError = None
 
 
+@method_decorator(cache_page(60 * 5), name="list")
+@method_decorator(cache_page(60 * 5), name="retrieve")
 class QueueViewSet(viewsets.ReadOnlyModelViewSet):
     """API endpoint that allows queues to be viewed."""
 
@@ -34,11 +41,14 @@ class QueueViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
 
+@method_decorator(cache_page(60 * 5), name="list")
+@method_decorator(cache_page(60 * 5), name="retrieve")
 class PatientViewSet(viewsets.ModelViewSet):
     """API endpoint that allows patients to be viewed or edited."""
 
     queryset = Patient.objects.all().order_by("registration_number")
     serializer_class = PatientSerializer
+    pagination_class = StandardResultsSetPagination
     # Use registration_number for single patient lookups
     lookup_field = "registration_number"
     permission_classes = [permissions.IsAuthenticated]
@@ -57,15 +67,26 @@ class PatientViewSet(viewsets.ModelViewSet):
         queryset = super().get_queryset()
         reg_nums = self.request.query_params.get("registration_numbers")
         if reg_nums:
-
+            numbers = [n.strip() for n in reg_nums.split(",") if n.strip().isdigit()]
             if numbers:
-                queryset = queryset.filter(
-                    registration_number__in=numbers
-                )
+                queryset = queryset.filter(registration_number__in=numbers)
             else:
                 return Patient.objects.none()
         return queryset
 
+    def perform_create(self, serializer):
+        cache.clear()
+        return super().perform_create(serializer)
+
+    def perform_update(self, serializer):
+        cache.clear()
+        return super().perform_update(serializer)
+
+    def perform_destroy(self, instance):
+        cache.clear()
+        return super().perform_destroy(instance)
+
+    @method_decorator(cache_page(60 * 5))
     @action(detail=False, methods=["get"], url_path="search")
     def search(self, request):
         """
@@ -106,6 +127,7 @@ class PatientViewSet(viewsets.ModelViewSet):
 class VisitViewSet(viewsets.ModelViewSet):
     queryset = Visit.objects.all()
     serializer_class = VisitSerializer
+    pagination_class = StandardResultsSetPagination
     permission_classes = [permissions.IsAuthenticated]
 
     def get_permissions(self):

--- a/clinicq_backend/clinicq_backend/settings.py
+++ b/clinicq_backend/clinicq_backend/settings.py
@@ -126,13 +126,21 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 
+# Simple in-memory cache backend
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "clinicq-cache",
+    }
+}
+
 # Logging configuration
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
         "json": {
-            "()": "pythonjsonlogger.JsonFormatter",
+            "()": "pythonjsonlogger.jsonlogger.JsonFormatter",
             "fmt": "%(asctime)s %(levelname)s %(name)s %(message)s",
         },
     },
@@ -146,6 +154,8 @@ LOGGING = {
         "handlers": ["console"],
         "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
     },
+}
+
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication",


### PR DESCRIPTION
## Summary
- paginate patient and visit endpoints with a shared PageNumberPagination class
- cache queue and patient responses and clear cache on patient modifications
- add simple in-memory cache backend and adjust tests for paginated responses

## Testing
- `cd clinicq_backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a533de94ec8323b29d44acb8c54685