### PR TITLE
Refactor group-based permissions with reusable base class

### DIFF
--- a/clinicq_backend/api/permissions.py
+++ b/clinicq_backend/api/permissions.py
@@ -1,23 +1,26 @@
 from rest_framework import permissions
 
 
-class IsDoctor(permissions.BasePermission):
+class IsInGroup(permissions.BasePermission):
+    """Generic permission that checks membership in a specific group."""
+
+    group_name = ""
+
+    def has_permission(self, request, view):
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.groups.filter(name=self.group_name).exists()
+        )
+
+
+class IsDoctor(IsInGroup):
     """Allows access only to users in the 'doctor' group."""
 
-    def has_permission(self, request, view):
-        return bool(
-            request.user
-            and request.user.is_authenticated
-            and request.user.groups.filter(name="doctor").exists()
-        )
+    group_name = "doctor"
 
 
-class IsAssistant(permissions.BasePermission):
+class IsAssistant(IsInGroup):
     """Allows access only to users in the 'assistant' group."""
 
-    def has_permission(self, request, view):
-        return bool(
-            request.user
-            and request.user.is_authenticated
-            and request.user.groups.filter(name="assistant").exists()
-        )
+    group_name = "assistant"


### PR DESCRIPTION
## Summary
- add `IsInGroup` permission for generic group membership checks
- refactor `IsDoctor` and `IsAssistant` to inherit from `IsInGroup`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2b3c108d483238ba6ff3474f8610b