### PR TITLE
Use in-memory auth tokens and refresh flow

### DIFF
--- a/clinicq_frontend/src/api.js
+++ b/clinicq_frontend/src/api.js
@@ -1,13 +1,54 @@
 import axios from 'axios';
 
-const api = axios.create();
+// Store the short-lived access token in memory only
+let accessToken = null;
+
+export const setAccessToken = (token) => {
+  accessToken = token;
+};
+
+export const clearAccessToken = () => {
+  accessToken = null;
+};
+
+// Use HTTP-only cookies for refresh tokens; send credentials on requests
+const api = axios.create({
+  withCredentials: true,
+});
 
 api.interceptors.request.use((config) => {
-  const token = window.localStorage.getItem('token');
-  if (token) {
-    config.headers.Authorization = `Token ${token}`;
+  // Attach access token from memory when available
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
   }
   return config;
 });
+
+// Attempt to refresh the access token transparently on 401 responses
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const { response, config } = error;
+    if (response && response.status === 401 && !config.__isRetryRequest) {
+      try {
+        const refreshResponse = await axios.post(
+          '/api/auth/refresh/',
+          {},
+          { withCredentials: true }
+        );
+        const newToken = refreshResponse.data.token;
+        if (newToken) {
+          setAccessToken(newToken);
+          config.__isRetryRequest = true;
+          config.headers.Authorization = `Bearer ${newToken}`;
+          return api(config);
+        }
+      } catch {
+        clearAccessToken();
+      }
+    }
+    return Promise.reject(error);
+  }
+);
 
 export default api;

--- a/clinicq_frontend/src/pages/DoctorPage.jsx
+++ b/clinicq_frontend/src/pages/DoctorPage.jsx
@@ -1,4 +1,3 @@
-/* global process */
 import { useState, useEffect, useCallback } from 'react';
 import api from '../api';
 import { Link } from 'react-router-dom';

--- a/clinicq_frontend/src/pages/LoginPage.jsx
+++ b/clinicq_frontend/src/pages/LoginPage.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import api from '../api';
+import api, { setAccessToken } from '../api';
 
 const LoginPage = () => {
   const [username, setUsername] = useState('');
@@ -18,7 +18,8 @@ const LoginPage = () => {
       });
       const token = response.data.token;
       if (token) {
-        window.localStorage.setItem('token', token);
+        // Store token in memory rather than localStorage for security
+        setAccessToken(token);
         navigate('/');
       } else {
         setError('No token returned');


### PR DESCRIPTION
## Summary
- Avoid localStorage for auth tokens by using in-memory storage and HTTP-only cookies
- Refresh access tokens automatically and rely on server-side role checks
- Fix linter complaint by removing unused `process` directive in Doctor page

## Testing
- `npm test`
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2cd8f8b1c8323a3a6db6d399cede5