### PR TITLE
Support DATABASE_URL configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+*   **Configuration**: Django now reads database settings from the `DATABASE_URL` environment variable using `dj-database-url`,
+    falling back to the local SQLite database when the variable is absent.
 *   **Visit Model**:
     *   Added `patient` (ForeignKey to `Patient`) and `queue` (ForeignKey to `Queue`) fields.
     *   `unique_together` constraint updated to `('token_number', 'visit_date', 'queue')`.

--- a/clinicq_backend/clinicq_backend/settings.py
+++ b/clinicq_backend/clinicq_backend/settings.py
@@ -13,6 +13,9 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 from pathlib import Path
 import os
 
+import dj_database_url
+from django.core.exceptions import ImproperlyConfigured
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -76,12 +79,33 @@ WSGI_APPLICATION = "clinicq_backend.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+_database_url = os.environ.get("DATABASE_URL")
+
+if _database_url is None:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
     }
-}
+else:
+    sanitized_database_url = _database_url.strip()
+    if not sanitized_database_url:
+        raise ImproperlyConfigured(
+            "DATABASE_URL is set but empty. Please provide a valid database connection URL."
+        )
+
+    try:
+        DATABASES = {
+            "default": dj_database_url.parse(
+                sanitized_database_url,
+                conn_max_age=600,
+            )
+        }
+    except (ValueError, dj_database_url.ParseError, dj_database_url.UnknownSchemeError) as exc:
+        raise ImproperlyConfigured(
+            f"DATABASE_URL is set but could not be parsed: {exc}."
+        ) from exc
 
 
 # Password validation

--- a/clinicq_backend/requirements.txt
+++ b/clinicq_backend/requirements.txt
@@ -6,3 +6,4 @@ psycopg2-binary~=2.9.9
 google-api-python-client==2.127.0
 google-auth>=2.0.0
 python-json-logger==2.0.7
+dj-database-url==3.0.1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,6 +22,9 @@ Create a `.env` file (an example is provided at `deploy/.env.example`) with valu
 * Optional superuser variables: `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_EMAIL`, `DJANGO_SUPERUSER_PASSWORD`
 * Any additional settings used by the project (e.g. `CORS_ALLOWED_ORIGINS`)
 
+The backend relies on [`dj-database-url`](https://pypi.org/project/dj-database-url/) to parse `DATABASE_URL`. If the variable is
+set but malformed, Django will raise an `ImproperlyConfigured` error during startup.
+
 For the frontend, configure `VITE_API_BASE_URL` so the compiled React app knows how to reach the backend API.
 
 ## Launching the backend
@@ -92,6 +95,9 @@ Create a `.env` file based on [`deploy/.env.example`](../deploy/.env.example) an
 - `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_EMAIL`, `DJANGO_SUPERUSER_PASSWORD` – optional initial superuser
 - `CORS_ALLOWED_ORIGINS` – allowed origins if backend and frontend are on different hosts
 - `VITE_API_BASE_URL` – API base URL used by the frontend build
+
+The backend parses `DATABASE_URL` using [`dj-database-url`](https://pypi.org/project/dj-database-url/). Providing an invalid URL
+causes Django to raise an `ImproperlyConfigured` exception at startup.
 
 ## Running the Backend
 


### PR DESCRIPTION
## Summary
- parse the `DATABASE_URL` environment variable with `dj-database-url` and fall back to SQLite when it is absent
- add `dj-database-url` to backend dependencies and document the new configuration behavior
- note the configuration change in the changelog

## Testing
- pytest *(fails: api/test_api.py::VisitLifecycleTests::test_doctor_can_transition_start_to_in_room – NoReverseMatch: Reverse for 'visit-in_room' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4769021083238d8b68c14b696261