### PR TITLE
Normalize frontend API base URL handling

### DIFF
--- a/clinicq_frontend/src/App.test.jsx
+++ b/clinicq_frontend/src/App.test.jsx
@@ -48,13 +48,13 @@ describe('Displays last_5_visit_dates', () => {
 
   test('Assistant page shows last visit dates for patient', async () => {
     api.get.mockImplementation((url) => {
-      if (url === '/api/queues/') {
+      if (url === '/queues/') {
         return Promise.resolve({ data: [{ id: 1, name: 'General' }] });
       }
-      if (url.startsWith('/api/patients/search/')) {
+      if (url.startsWith('/patients/search/')) {
         return Promise.resolve({ data: [{ registration_number: 1 }] });
       }
-      if (url === '/api/patients/1/') {
+      if (url === '/patients/1/') {
         return Promise.resolve({
           data: {
             registration_number: 1,
@@ -92,31 +92,31 @@ describe('Displays last_5_visit_dates', () => {
 
   test('Doctor page shows last visit dates for waiting patients', async () => {
     api.get.mockImplementation((url) => {
-        if (url.includes('/api/visits')) {
-            return Promise.resolve({
-              data: [
-                {
-                  id: 1,
-                  token_number: 10,
-                  patient_full_name: 'Alice',
-                  patient_registration_number: 1,
-                  status: 'WAITING',
-                },
-              ],
-            });
-          }
-          if (url.includes('/api/patients')) {
-            return Promise.resolve({
-              data: [
-                {
-                  registration_number: 1,
-                  last_5_visit_dates: ['2024-01-01', '2023-12-31'],
-                  gender: 'FEMALE',
-                },
-              ],
-            });
-          }
-          return Promise.resolve({ data: [] });
+      if (url.includes('/visits')) {
+        return Promise.resolve({
+          data: [
+            {
+              id: 1,
+              token_number: 10,
+              patient_full_name: 'Alice',
+              patient_registration_number: 1,
+              status: 'WAITING',
+            },
+          ],
+        });
+      }
+      if (url.includes('/patients')) {
+        return Promise.resolve({
+          data: [
+            {
+              registration_number: 1,
+              last_5_visit_dates: ['2024-01-01', '2023-12-31'],
+              gender: 'FEMALE',
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ data: [] });
     });
 
     render(

--- a/clinicq_frontend/src/AuthContext.jsx
+++ b/clinicq_frontend/src/AuthContext.jsx
@@ -8,7 +8,7 @@ export const AuthProvider = ({ children }) => {
 
   const fetchRoles = async () => {
     try {
-      const response = await api.get('/api/auth/me/');
+      const response = await api.get('/auth/me/');
       setRoles(response.data.roles || []);
     } catch {
       setRoles([]);

--- a/clinicq_frontend/src/__tests__/DoctorPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/DoctorPage.test.jsx
@@ -30,23 +30,23 @@ const mockVisits = [
 ];
 
 const mockPatientDetails = {
-    P001: { registration_number: 'P001', gender: 'MALE', last_5_visit_dates: [] },
-    P002: { registration_number: 'P002', gender: 'FEMALE', last_5_visit_dates: [] },
-    P003: { registration_number: 'P003', gender: 'OTHER', last_5_visit_dates: [] },
+  P001: { registration_number: 'P001', gender: 'MALE', last_5_visit_dates: [] },
+  P002: { registration_number: 'P002', gender: 'FEMALE', last_5_visit_dates: [] },
+  P003: { registration_number: 'P003', gender: 'OTHER', last_5_visit_dates: [] },
 };
 
 beforeEach(() => {
   api.get.mockImplementation((url) => {
-    if (url.includes('/api/visits')) {
+    if (url.includes('/visits')) {
       return Promise.resolve({ data: mockVisits });
     }
-    if (url.includes('/api/patients')) {
-        const regNumbers = url.split('=')[1].split(',');
-        const patients = regNumbers.map(reg => mockPatientDetails[reg]).filter(Boolean);
+    if (url.includes('/patients')) {
+      const regNumbers = url.split('=')[1].split(',');
+      const patients = regNumbers.map((reg) => mockPatientDetails[reg]).filter(Boolean);
       return Promise.resolve({ data: patients });
     }
-    if (url.includes('/api/queues')) {
-        return Promise.resolve({ data: [] });
+    if (url.includes('/queues')) {
+      return Promise.resolve({ data: [] });
     }
     return Promise.resolve({ data: [] });
   });
@@ -78,46 +78,46 @@ test('renders Doctor dashboard and displays visits with correct action buttons',
 });
 
 test('clicking "Start Consultation" calls the correct API endpoint', async () => {
-    render(
-      <MemoryRouter>
-        <DoctorPage />
-      </MemoryRouter>
-    );
+  render(
+    <MemoryRouter>
+      <DoctorPage />
+    </MemoryRouter>
+  );
 
-    const startButton = await screen.findByText(/Start Consultation/i);
-    fireEvent.click(startButton);
+  const startButton = await screen.findByText(/Start Consultation/i);
+  fireEvent.click(startButton);
 
-    await waitFor(() => {
-      expect(api.patch).toHaveBeenCalledWith('/api/visits/1/start/');
-    });
+  await waitFor(() => {
+    expect(api.patch).toHaveBeenCalledWith('/visits/1/start/');
+  });
 });
 
 test('clicking "Move to Room" calls the correct API endpoint', async () => {
-    render(
-      <MemoryRouter>
-        <DoctorPage />
-      </MemoryRouter>
-    );
+  render(
+    <MemoryRouter>
+      <DoctorPage />
+    </MemoryRouter>
+  );
 
-    const moveButton = await screen.findByText(/Move to Room/i);
-    fireEvent.click(moveButton);
+  const moveButton = await screen.findByText(/Move to Room/i);
+  fireEvent.click(moveButton);
 
-    await waitFor(() => {
-      expect(api.patch).toHaveBeenCalledWith('/api/visits/2/in_room/');
-    });
+  await waitFor(() => {
+    expect(api.patch).toHaveBeenCalledWith('/visits/2/in_room/');
+  });
 });
 
 test('clicking "Mark as Done" calls the correct API endpoint', async () => {
-    render(
-      <MemoryRouter>
-        <DoctorPage />
-      </MemoryRouter>
-    );
+  render(
+    <MemoryRouter>
+      <DoctorPage />
+    </MemoryRouter>
+  );
 
-    const doneButton = await screen.findByText(/Mark as Done/i);
-    fireEvent.click(doneButton);
+  const doneButton = await screen.findByText(/Mark as Done/i);
+  fireEvent.click(doneButton);
 
-    await waitFor(() => {
-      expect(api.patch).toHaveBeenCalledWith('/api/visits/3/done/');
-    });
+  await waitFor(() => {
+    expect(api.patch).toHaveBeenCalledWith('/visits/3/done/');
+  });
 });

--- a/clinicq_frontend/src/__tests__/DoctorPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/DoctorPage.test.jsx
@@ -42,7 +42,7 @@ beforeEach(() => {
     }
     if (url.includes('/patients')) {
       const regNumbers = url.split('=')[1].split(',');
-      const patients = regNumbers.map((reg) => mockPatientDetails[reg]).filter(Boolean);
+      const patients = regNumbers.map(reg => mockPatientDetails[reg]).filter(Boolean);
       return Promise.resolve({ data: patients });
     }
     if (url.includes('/queues')) {

--- a/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
@@ -28,11 +28,11 @@ const mockVisits = [
 
 beforeEach(() => {
   api.get.mockImplementation((url) => {
-    if (url.includes('/api/visits')) {
+    if (url.includes('/visits')) {
       return Promise.resolve({ data: mockVisits });
     }
-    if (url.includes('/api/queues')) {
-        return Promise.resolve({ data: [] });
+    if (url.includes('/queues')) {
+      return Promise.resolve({ data: [] });
     }
     return Promise.resolve({ data: [] });
   });
@@ -62,22 +62,22 @@ test('renders Public Display and shows IN_ROOM and WAITING patients correctly', 
 });
 
 test('shows correct message when no patients are present', async () => {
-    api.get.mockImplementation((url) => {
-        if (url.includes('/api/visits')) {
-          return Promise.resolve({ data: [] });
-        }
-        if (url.includes('/api/queues')) {
-            return Promise.resolve({ data: [] });
-        }
-        return Promise.resolve({ data: [] });
-      });
+  api.get.mockImplementation((url) => {
+    if (url.includes('/visits')) {
+      return Promise.resolve({ data: [] });
+    }
+    if (url.includes('/queues')) {
+      return Promise.resolve({ data: [] });
+    }
+    return Promise.resolve({ data: [] });
+  });
 
-    render(
-      <MemoryRouter>
-        <PublicDisplayPage />
-      </MemoryRouter>
-    );
+  render(
+    <MemoryRouter>
+      <PublicDisplayPage />
+    </MemoryRouter>
+  );
 
-    expect(await screen.findByText(/No patient is currently in the room./i)).toBeInTheDocument();
-    expect(await screen.findByText(/The waiting queue is empty./i)).toBeInTheDocument();
+  expect(await screen.findByText(/No patient is currently in the room./i)).toBeInTheDocument();
+  expect(await screen.findByText(/The waiting queue is empty./i)).toBeInTheDocument();
 });

--- a/clinicq_frontend/src/api.js
+++ b/clinicq_frontend/src/api.js
@@ -20,7 +20,7 @@ const normalizeApiBase = (value) => {
     return DEFAULT_API_PATH;
   }
 
-  if (/\/api(?:\/|$)/i.test(withoutTrailingSlash)) {
+  if (/\/api(?:\/|$)/.test(withoutTrailingSlash)) {
     return withoutTrailingSlash;
   }
 

--- a/clinicq_frontend/src/pages/AssistantPage.jsx
+++ b/clinicq_frontend/src/pages/AssistantPage.jsx
@@ -14,7 +14,7 @@ const AssistantPage = () => {
   useEffect(() => {
     const fetchQueues = async () => {
       try {
-        const response = await api.get('/api/queues/');
+        const response = await api.get('/queues/');
         setQueues(response.data || []);
       } catch (err) {
         console.error('Error fetching queues:', err);
@@ -32,11 +32,11 @@ const AssistantPage = () => {
       }
       try {
         const searchResp = await api.get(
-          `/api/patients/search/?q=${encodeURIComponent(registrationNumber.trim())}`
+          `/patients/search/?q=${encodeURIComponent(registrationNumber.trim())}`
         );
         if (Array.isArray(searchResp.data) && searchResp.data.length > 0) {
           const regNo = searchResp.data[0].registration_number;
-          const detailResp = await api.get(`/api/patients/${regNo}/`);
+          const detailResp = await api.get(`/patients/${regNo}/`);
           setPatientInfo(detailResp.data);
         } else {
           setPatientInfo(null);
@@ -74,7 +74,7 @@ const AssistantPage = () => {
     }
 
     try {
-      const response = await api.post('/api/visits/', {
+      const response = await api.post('/visits/', {
         patient: patientInfo.registration_number,
         queue: selectedQueue,
       });

--- a/clinicq_frontend/src/pages/DoctorPage.jsx
+++ b/clinicq_frontend/src/pages/DoctorPage.jsx
@@ -15,7 +15,7 @@ const DoctorPage = () => {
     setError('');
     try {
       const queueParam = selectedQueue ? `&queue=${selectedQueue}` : '';
-      const response = await api.get(`/api/visits/?status=WAITING,START,IN_ROOM${queueParam}`);
+      const response = await api.get(`/visits/?status=WAITING,START,IN_ROOM${queueParam}`);
       const fetchedVisits = response.data || [];
 
       const registrationNumbers = [
@@ -26,7 +26,7 @@ const DoctorPage = () => {
       if (registrationNumbers.length > 0) {
         // This logic can be simplified if the backend provides patient details directly
         const patientsResp = await api.get(
-          `/api/patients/?registration_numbers=${registrationNumbers.join(',')}`
+          `/patients/?registration_numbers=${registrationNumbers.join(',')}`
         );
         patientsByRegNum = (patientsResp.data || []).reduce((acc, patient) => {
           acc[patient.registration_number] = patient;
@@ -44,7 +44,7 @@ const DoctorPage = () => {
         withImages = await Promise.all(
           detailedVisits.map(async (v) => {
             try {
-              const imgResp = await api.get(`/api/prescriptions/?visit=${v.id}`);
+              const imgResp = await api.get(`/prescriptions/?visit=${v.id}`);
               return { ...v, prescription_images: imgResp.data || [] };
             } catch {
               return { ...v, prescription_images: [] };
@@ -66,7 +66,7 @@ const DoctorPage = () => {
     if (import.meta.env.MODE === 'test') return;
     const fetchQueues = async () => {
       try {
-        const response = await api.get('/api/queues/');
+        const response = await api.get('/queues/');
         setQueues(response.data || []);
       } catch (err) {
         console.error('Error fetching queues:', err);
@@ -81,7 +81,7 @@ const DoctorPage = () => {
 
   const handleUpdateVisitStatus = async (visitId, action) => {
     try {
-      await api.patch(`/api/visits/${visitId}/${action}/`);
+      await api.patch(`/visits/${visitId}/${action}/`);
       fetchVisits(); // Refetch to get the latest state
     } catch (err) {
       console.error(`Error during action ${action} for visit ${visitId}:`, err);
@@ -107,8 +107,8 @@ const DoctorPage = () => {
       const form = new FormData();
       form.append('visit', visitId);
       form.append('image', state.file);
-      await api.post('/api/prescriptions/', form);
-      const imgResp = await api.get(`/api/prescriptions/?visit=${visitId}`);
+      await api.post('/prescriptions/', form);
+      const imgResp = await api.get(`/prescriptions/?visit=${visitId}`);
       setVisits((prev) =>
         prev.map((v) =>
           v.id === visitId

--- a/clinicq_frontend/src/pages/LoginPage.jsx
+++ b/clinicq_frontend/src/pages/LoginPage.jsx
@@ -14,7 +14,7 @@ const LoginPage = () => {
     e.preventDefault();
     setError('');
     try {
-      const response = await api.post('/api/auth/login/', {
+      const response = await api.post('/auth/login/', {
         username,
         password,
       });

--- a/clinicq_frontend/src/pages/PatientFormPage.jsx
+++ b/clinicq_frontend/src/pages/PatientFormPage.jsx
@@ -21,14 +21,14 @@ const PatientFormPage = () => {
   useEffect(() => {
     const fetchPatient = async () => {
       try {
-        const response = await api.get(`/api/patients/${registration_number}/`);
+        const response = await api.get(`/patients/${registration_number}/`);
         setFormData({
           name: response.data.name || '',
           phone: response.data.phone || '',
           gender: response.data.gender || 'OTHER',
           age: response.data.age || '',
         });
-        const imgResp = await api.get(`/api/prescriptions/?patient=${registration_number}`);
+        const imgResp = await api.get(`/prescriptions/?patient=${registration_number}`);
         setImages(imgResp.data || []);
       } catch (err) {
         console.error('Failed to load patient', err);
@@ -50,9 +50,9 @@ const PatientFormPage = () => {
     setError('');
     try {
       if (isEdit) {
-        await api.put(`/api/patients/${registration_number}/`, formData);
+        await api.put(`/patients/${registration_number}/`, formData);
       } else {
-        await api.post('/api/patients/', formData);
+        await api.post('/patients/', formData);
       }
       navigate('/patients');
     } catch (err) {

--- a/clinicq_frontend/src/pages/PatientsPage.jsx
+++ b/clinicq_frontend/src/pages/PatientsPage.jsx
@@ -13,9 +13,9 @@ const PatientsPage = () => {
     setLoading(true);
     setError('');
     try {
-      let url = '/api/patients/';
+      let url = '/patients/';
       if (term.trim()) {
-        url = `/api/patients/search/?q=${encodeURIComponent(term.trim())}`;
+        url = `/patients/search/?q=${encodeURIComponent(term.trim())}`;
       }
       const response = await api.get(url);
       setPatients(response.data);
@@ -34,7 +34,7 @@ const PatientsPage = () => {
   const handleDelete = async (regNum) => {
     if (!window.confirm('Are you sure you want to delete this patient?')) return;
     try {
-      await api.delete(`/api/patients/${regNum}/`);
+      await api.delete(`/patients/${regNum}/`);
       setPatients((prev) => prev.filter((p) => p.registration_number !== regNum));
     } catch (err) {
       console.error('Delete failed', err);

--- a/clinicq_frontend/src/pages/PublicDisplayPage.jsx
+++ b/clinicq_frontend/src/pages/PublicDisplayPage.jsx
@@ -18,7 +18,7 @@ const PublicDisplayPage = ({ initialQueue = '' }) => {
       setError('');
       try {
         const queueParam = selectedQueue ? `&queue=${selectedQueue}` : '';
-        const response = await api.get(`/api/visits/?status=WAITING,IN_ROOM${queueParam}`);
+        const response = await api.get(`/visits/?status=WAITING,IN_ROOM${queueParam}`);
         const allVisits = response.data || [];
 
         setInRoomVisits(allVisits.filter(v => v.status === 'IN_ROOM'));
@@ -45,7 +45,7 @@ const PublicDisplayPage = ({ initialQueue = '' }) => {
   useEffect(() => {
     const fetchQueues = async () => {
       try {
-        const response = await api.get('/api/queues/');
+        const response = await api.get('/queues/');
         setQueues(response.data || []);
       } catch (err) {
         console.error('Error fetching queues:', err);

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -32,3 +32,7 @@ DJANGO_SUPERUSER_PASSWORD=YourSecurePassword123! # Change this!
 # MEDIA_ROOT=/srv/clinicq/media
 # STATIC_URL=/static/
 # MEDIA_URL=/media/
+
+# Frontend Settings
+VITE_API_BASE_URL=http://localhost:8000
+# The frontend helper appends the /api prefix automatically; avoid including it twice.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - CHOKIDAR_USEPOLLING=true # For better hot-reloading in some Docker environments
       - WDS_SOCKET_PORT=5173 # For Vite HMR proxying if needed
       # Vite specific env vars can be prefixed with VITE_
-      - VITE_API_BASE_URL=http://localhost:8000/api # So frontend knows where backend is
+      - VITE_API_BASE_URL=http://backend:8000 # Base host; api helper appends /api path
     depends_on:
       - backend
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,7 +22,7 @@ Create a `.env` file (an example is provided at `deploy/.env.example`) with valu
 * Optional superuser variables: `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_EMAIL`, `DJANGO_SUPERUSER_PASSWORD`
 * Any additional settings used by the project (e.g. `CORS_ALLOWED_ORIGINS`)
 
-For the frontend, configure `VITE_API_BASE_URL` so the compiled React app knows how to reach the backend API.
+For the frontend, set `VITE_API_BASE_URL` to the backend host (for example `http://localhost:8000`). The frontend helper automatically appends the `/api` prefix, so avoid adding it twice.
 
 ## Launching the backend
 
@@ -91,7 +91,7 @@ Create a `.env` file based on [`deploy/.env.example`](../deploy/.env.example) an
 - `DATABASE_URL` – PostgreSQL connection string
 - `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_EMAIL`, `DJANGO_SUPERUSER_PASSWORD` – optional initial superuser
 - `CORS_ALLOWED_ORIGINS` – allowed origins if backend and frontend are on different hosts
-- `VITE_API_BASE_URL` – API base URL used by the frontend build
+- `VITE_API_BASE_URL` – Backend host used by the frontend build (omit `/api`; the helper appends it)
 
 ## Running the Backend
 


### PR DESCRIPTION
## Summary
- normalize the frontend API helper to derive a clean base URL from `VITE_API_BASE_URL` and reuse it for refresh requests
- update React pages and related tests to call endpoints without hard-coded `/api/` prefixes
- document the new configuration expectations for `VITE_API_BASE_URL` in docker-compose and the shared env template

## Testing
- `npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_68cb476cbc7c8323a9677d3035eeb891