### PR TITLE
Handle 401 auth failures without refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ This project is being developed in **stages** using AI coding agents (Jules + Gi
 - **Stage 3**: Deep testing and debugging
 
 See `development_plan.md` and `task_graph.md` for details.
+
+## Authentication Flow
+
+The backend exposes Django REST Framework's token authentication via
+`POST /api/auth/login/`. The frontend keeps the returned access token in memory
+only; it is **not** persisted to local storage. There is no refresh token
+endpoint—when the server responds with `401 Unauthorized`, the frontend clears
+any cached token state and redirects users back to the login screen so they can
+authenticate again.

--- a/clinicq_frontend/src/api.js
+++ b/clinicq_frontend/src/api.js
@@ -2,16 +2,19 @@ import axios from 'axios';
 
 // Store the short-lived access token in memory only
 let accessToken = null;
+let redirectingToLogin = false;
 
 export const setAccessToken = (token) => {
   accessToken = token;
+  redirectingToLogin = false;
 };
 
 export const clearAccessToken = () => {
   accessToken = null;
+  redirectingToLogin = false;
 };
 
-// Use HTTP-only cookies for refresh tokens; send credentials on requests
+// Configure axios instance and send credentials for any cookie-backed endpoints
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || "",
   withCredentials: true,
@@ -25,27 +28,26 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-// Attempt to refresh the access token transparently on 401 responses
+// When we receive a 401, clear any cached auth state and send the user back to login
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const { response, config } = error;
-    if (response && response.status === 401 && !config.__isRetryRequest) {
-      try {
-        const refreshResponse = await axios.post(
-          '/api/auth/refresh/',
-          {},
-          { withCredentials: true }
-        );
-        const newToken = refreshResponse.data.token;
-        if (newToken) {
-          setAccessToken(newToken);
-          config.__isRetryRequest = true;
-          config.headers.Authorization = `Bearer ${newToken}`;
-          return api(config);
-        }
-      } catch {
+
+    if (response && response.status === 401) {
+      const isLoginRequest = config?.url?.includes('/api/auth/login/');
+
+      // Avoid redirect loops if the login endpoint itself bubbles a 401
+      if (!isLoginRequest) {
         clearAccessToken();
+
+        if (!redirectingToLogin) {
+          redirectingToLogin = true;
+
+          if (typeof window !== 'undefined' && window.location.pathname !== '/login') {
+            window.location.assign('/login');
+          }
+        }
       }
     }
     return Promise.reject(error);

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,16 @@
 # ClinicQ API Overview
 
-The ClinicQ backend exposes a RESTful API under the `/api/` prefix.
+The ClinicQ backend exposes a RESTful API under the `/api/` prefix. Authentication
+uses Django REST Framework's token authentication and currently supports only
+login—tokens are short-lived in the frontend (kept in memory) and **no refresh
+endpoint is provided**. When a token expires or becomes invalid the frontend will
+clear its session and redirect the user to log in again.
+
 The following endpoints are useful during development. Replace `<id>` or `<reg_no>`
 with the appropriate identifiers.
+
+## Authentication
+- `POST /api/auth/login/` – Retrieve a token for subsequent API calls (include `username` and `password` in the body)
 
 ## Patients
 - `GET /api/patients/` – List patients


### PR DESCRIPTION
## Summary
- remove the unused refresh-token retry logic from the axios client and redirect to login when a 401 is returned
- reset in-memory auth state whenever a new token is set or cleared so repeat logins work cleanly
- document the token-based authentication approach and lack of refresh endpoint in the README and API docs

## Testing
- npm run lint *(fails: pre-existing lint errors in AuthContext.jsx and DoctorPage.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cb476d9f80832399f3b29cc8204909