### PR TITLE
Handle paginated visits on public display

### DIFF
--- a/clinicq_frontend/src/__mocks__/api.js
+++ b/clinicq_frontend/src/__mocks__/api.js
@@ -1,0 +1,13 @@
+const mockApi = {
+  get: jest.fn(),
+  post: jest.fn(),
+  patch: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+  interceptors: {
+    request: { use: jest.fn() },
+    response: { use: jest.fn() },
+  },
+};
+
+export default mockApi;

--- a/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/PublicDisplayPage.test.jsx
@@ -29,7 +29,7 @@ const mockVisits = [
 beforeEach(() => {
   api.get.mockImplementation((url) => {
     if (url.includes('/visits')) {
-      return Promise.resolve({ data: mockVisits });
+      return Promise.resolve({ data: { results: mockVisits } });
     }
     if (url.includes('/queues')) {
       return Promise.resolve({ data: [] });
@@ -64,7 +64,7 @@ test('renders Public Display and shows IN_ROOM and WAITING patients correctly', 
 test('shows correct message when no patients are present', async () => {
   api.get.mockImplementation((url) => {
     if (url.includes('/visits')) {
-      return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: { results: [] } });
     }
     if (url.includes('/queues')) {
       return Promise.resolve({ data: [] });

--- a/clinicq_frontend/src/pages/PublicDisplayPage.jsx
+++ b/clinicq_frontend/src/pages/PublicDisplayPage.jsx
@@ -19,10 +19,14 @@ const PublicDisplayPage = ({ initialQueue = '' }) => {
       try {
         const queueParam = selectedQueue ? `&queue=${selectedQueue}` : '';
         const response = await api.get(`/visits/?status=WAITING,IN_ROOM${queueParam}`);
-        const allVisits = response.data || [];
+        const visitResults = Array.isArray(response?.data?.results)
+          ? response.data.results
+          : Array.isArray(response?.data)
+            ? response.data
+            : [];
 
-        setInRoomVisits(allVisits.filter(v => v.status === 'IN_ROOM'));
-        setWaitingVisits(allVisits.filter(v => v.status === 'WAITING'));
+        setInRoomVisits(visitResults.filter(v => v.status === 'IN_ROOM'));
+        setWaitingVisits(visitResults.filter(v => v.status === 'WAITING'));
 
       } catch (err) {
         console.error("Error fetching visits:", err);


### PR DESCRIPTION
## Summary
- update the public display queue fetch logic to read visit data from paginated responses
- keep in-room and waiting filtering working with the resolved visit list shape
- add a Jest mock and test coverage to exercise the paginated payload structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2a97823b88323a58776d57a098c14