### PR TITLE
Make group permission checks case-insensitive

### DIFF
--- a/clinicq_backend/api/permissions.py
+++ b/clinicq_backend/api/permissions.py
@@ -10,7 +10,7 @@ class IsInGroup(permissions.BasePermission):
         return bool(
             request.user
             and request.user.is_authenticated
-            and request.user.groups.filter(name=self.group_name).exists()
+            and request.user.groups.filter(name__iexact=self.group_name).exists()
         )
 
 

--- a/clinicq_backend/api/test_permissions.py
+++ b/clinicq_backend/api/test_permissions.py
@@ -1,0 +1,32 @@
+import pytest
+from django.contrib.auth.models import Group, User
+from rest_framework.test import APIRequestFactory
+
+from .permissions import IsAdmin, IsAssistant, IsDisplay, IsDoctor
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "permission_class, group_name",
+    [
+        (IsDoctor, "Doctor"),
+        (IsAssistant, "Assistant"),
+        (IsAdmin, "Admin"),
+        (IsDisplay, "Display"),
+    ],
+)
+def test_seeded_group_members_have_permission(permission_class, group_name):
+    """Users assigned to the seeded auth groups should pass permission checks."""
+
+    factory = APIRequestFactory()
+    request = factory.get("/some-endpoint/")
+
+    user = User.objects.create_user(username=f"{group_name.lower()}_user")
+    group, _ = Group.objects.get_or_create(name=group_name)
+    user.groups.add(group)
+
+    request.user = user
+
+    permission = permission_class()
+
+    assert permission.has_permission(request, view=None)


### PR DESCRIPTION
## Summary
- update the shared permission helper to match groups case-insensitively so the seeded capitalized names work with existing lowercase references
- add unit coverage that confirms members of the seeded Admin/Doctor/Assistant/Display groups satisfy their permissions

## Testing
- python manage.py migrate
- pytest *(fails: clinicq_backend/api/test_api.py::VisitLifecycleTests::test_doctor_can_transition_start_to_in_room - NameError: name 'url' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ad4174e08323835932e7191c2065