### PR TITLE
Read ALLOWED_HOSTS from environment

### DIFF
--- a/clinicq_backend/clinicq_backend/settings.py
+++ b/clinicq_backend/clinicq_backend/settings.py
@@ -29,7 +29,12 @@ SECRET_KEY = "django-insecure-@$43#sqi9t4_2&u38$v@l+3p37m&sp04afnk$usaf6f0z+2-*a
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS: list[str] = []
+_raw_allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", "localhost")
+ALLOWED_HOSTS: list[str] = [
+    host.strip()
+    for host in _raw_allowed_hosts.split(",")
+    if host.strip()
+]
 
 
 # Application definition

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -3,7 +3,7 @@
 # Generate a new one for production, e.g., using python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
 SECRET_KEY=your_production_secret_key_here
 DEBUG=False
-ALLOWED_HOSTS=your_domain.com,www.your_domain.com,localhost,127.0.0.1
+DJANGO_ALLOWED_HOSTS=your_domain.com,www.your_domain.com,localhost,127.0.0.1
 
 # Database Settings (PostgreSQL)
 # Example: postgresql://user:password@host:port/dbname

--- a/deploy/clinicq.nginx
+++ b/deploy/clinicq.nginx
@@ -110,7 +110,7 @@ server {
 # 6. Create a symbolic link: `sudo ln -s /etc/nginx/sites-available/clinicq /etc/nginx/sites-enabled/clinicq`.
 # 7. Test Nginx configuration: `sudo nginx -t`.
 # 8. Reload Nginx: `sudo systemctl reload nginx`.
-# 9. Ensure Django's `ALLOWED_HOSTS` includes your domain.
+# 9. Ensure Django's `DJANGO_ALLOWED_HOSTS` includes your domain.
 # 10. Ensure Django's `STATIC_ROOT` (for `collectstatic`) is set to `$django_static_root`.
 #     And `MEDIA_ROOT` to `$django_media_root`.
 # 11. The React app should be built into `$react_app_root` (e.g., `clinicq_frontend/dist`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     environment:
       - SECRET_KEY=django_insecure_local_dev_secret_key_!@#%^&*()
       - DEBUG=True
+      - DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,backend
       - DATABASE_URL=postgresql://clinicq_dev_user:clinicq_dev_password@db:5432/clinicq_dev_db
       - DJANGO_SUPERUSER_USERNAME=admin
       - DJANGO_SUPERUSER_EMAIL=admin@example.com

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,7 +17,7 @@ Create a `.env` file (an example is provided at `deploy/.env.example`) with valu
 
 * `SECRET_KEY` – Django secret key
 * `DEBUG` – set to `False` in production
-* `ALLOWED_HOSTS` – comma‑separated list of allowed hostnames
+* `DJANGO_ALLOWED_HOSTS` – comma‑separated list of allowed hostnames
 * `DATABASE_URL` – connection string for PostgreSQL
 * Optional superuser variables: `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_EMAIL`, `DJANGO_SUPERUSER_PASSWORD`
 * Any additional settings used by the project (e.g. `CORS_ALLOWED_ORIGINS`)
@@ -86,7 +86,7 @@ Create a `.env` file based on [`deploy/.env.example`](../deploy/.env.example) an
 
 - `SECRET_KEY` – Django secret key
 - `DEBUG` – set to `False` in production
-- `ALLOWED_HOSTS` – comma-separated hostnames that can serve the app
+- `DJANGO_ALLOWED_HOSTS` – comma-separated hostnames that can serve the app
 - `DATABASE_URL` – PostgreSQL connection string
 - `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_EMAIL`, `DJANGO_SUPERUSER_PASSWORD` – optional initial superuser
 - `CORS_ALLOWED_ORIGINS` – allowed origins if backend and frontend are on different hosts


### PR DESCRIPTION
## Summary
- read `DJANGO_ALLOWED_HOSTS` from the environment and normalise the host list in Django settings
- document the new variable across deployment assets and templates
- provide defaults for local Docker usage so hosts work in development containers

## Testing
- python manage.py check --deploy

------
https://chatgpt.com/codex/tasks/task_e_68d2af69170c8323ad082a790eacebe5