### PR TITLE
Configure static file collection settings

### DIFF
--- a/clinicq_backend/clinicq_backend/settings.py
+++ b/clinicq_backend/clinicq_backend/settings.py
@@ -143,6 +143,13 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = "static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+STATICFILES_DIRS: list[Path] = []
+
+_frontend_dist = BASE_DIR / "clinicq_frontend" / "dist"
+if _frontend_dist.exists():
+    STATICFILES_DIRS.append(_frontend_dist)
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field


### PR DESCRIPTION
## Summary
- define STATIC_ROOT so Django collectstatic writes to a consistent directory
- auto-include the frontend dist folder in STATICFILES_DIRS when present for collection

## Testing
- python manage.py collectstatic --noinput

------
https://chatgpt.com/codex/tasks/task_e_68d2af68540883239b591a5614be93c4