### PR TITLE
Handle case-insensitive seeded group permissions

### DIFF
--- a/clinicq_backend/api/permissions.py
+++ b/clinicq_backend/api/permissions.py
@@ -10,7 +10,7 @@ class IsInGroup(permissions.BasePermission):
         return bool(
             request.user
             and request.user.is_authenticated
-            and request.user.groups.filter(name=self.group_name).exists()
+            and request.user.groups.filter(name__iexact=self.group_name).exists()
         )
 
 

--- a/clinicq_backend/api/test_api.py
+++ b/clinicq_backend/api/test_api.py
@@ -14,8 +14,8 @@ from freezegun import freeze_time
 class PatientAPITests(APITestCase):
     def setUp(self):
         cache.clear()
-        doctor_group, _ = Group.objects.get_or_create(name="doctor")
-        assistant_group, _ = Group.objects.get_or_create(name="assistant")
+        doctor_group, _ = Group.objects.get_or_create(name="Doctor")
+        assistant_group, _ = Group.objects.get_or_create(name="Assistant")
         user = User.objects.create_user(username="tester", password="pass")
         user.groups.add(doctor_group, assistant_group)
         token = Token.objects.create(user=user)
@@ -189,7 +189,8 @@ class PatientAPITests(APITestCase):
         url = reverse("auth-me")
         response = self.client.get(url, format="json")
         assert response.status_code == status.HTTP_200_OK
-        assert set(response.data.get("roles", [])) == {"doctor", "assistant"}
+        roles = {role.lower() for role in response.data.get("roles", [])}
+        assert roles == {"doctor", "assistant"}
 
     def test_patient_last_5_visit_dates(self):
         # Create a queue
@@ -224,8 +225,8 @@ class PatientAPITests(APITestCase):
 class QueueAPITests(APITestCase):
     def setUp(self):
         cache.clear()
-        doctor_group, _ = Group.objects.get_or_create(name="doctor")
-        assistant_group, _ = Group.objects.get_or_create(name="assistant")
+        doctor_group, _ = Group.objects.get_or_create(name="Doctor")
+        assistant_group, _ = Group.objects.get_or_create(name="Assistant")
         user = User.objects.create_user(username="queue_tester", password="pass")
         user.groups.add(doctor_group, assistant_group)
         token = Token.objects.create(user=user)
@@ -254,8 +255,8 @@ class QueueAPITests(APITestCase):
 class VisitAPITests(APITestCase):
     def setUp(self):
         cache.clear()
-        doctor_group, _ = Group.objects.get_or_create(name="doctor")
-        assistant_group, _ = Group.objects.get_or_create(name="assistant")
+        doctor_group, _ = Group.objects.get_or_create(name="Doctor")
+        assistant_group, _ = Group.objects.get_or_create(name="Assistant")
         user = User.objects.create_user(username="visit_tester", password="pass")
         user.groups.add(doctor_group, assistant_group)
         token = Token.objects.create(user=user)
@@ -505,9 +506,9 @@ class VisitAPITests(APITestCase):
 class VisitLifecycleTests(APITestCase):
     def setUp(self):
         cache.clear()
-        self.doctor_group, _ = Group.objects.get_or_create(name="doctor")
-        self.assistant_group, _ = Group.objects.get_or_create(name="assistant")
-        self.display_group, _ = Group.objects.get_or_create(name="display")
+        self.doctor_group, _ = Group.objects.get_or_create(name="Doctor")
+        self.assistant_group, _ = Group.objects.get_or_create(name="Assistant")
+        self.display_group, _ = Group.objects.get_or_create(name="Display")
 
         self.doctor_user = User.objects.create_user(username="doctor", password="password")
         self.doctor_user.groups.add(self.doctor_group)

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -164,7 +164,10 @@ class VisitViewSet(viewsets.ModelViewSet):
             permission_classes = [IsAssistant]
         elif self.action in ['start', 'in_room', 'send_back_to_waiting', 'done']:
             permission_classes = [IsDoctor]
-        elif self.action == 'list' and self.request.user.groups.filter(name='display').exists():
+        elif (
+            self.action == 'list'
+            and self.request.user.groups.filter(name__iexact='display').exists()
+        ):
             permission_classes = [IsDisplay]
         else:
             permission_classes = [permissions.IsAuthenticated]

--- a/clinicq_backend/tests/test_api.py
+++ b/clinicq_backend/tests/test_api.py
@@ -11,7 +11,7 @@ from api.models import Patient, Queue, Visit
 class PatientCRUDTests(APITestCase):
     def setUp(self):
         cache.clear()
-        doctor_group, _ = Group.objects.get_or_create(name="doctor")
+        doctor_group, _ = Group.objects.get_or_create(name="Doctor")
         user = User.objects.create_user(username="doc", password="pass")
         user.groups.add(doctor_group)
         token = Token.objects.create(user=user)
@@ -48,7 +48,7 @@ class PatientCRUDTests(APITestCase):
 class PatientFilterTests(APITestCase):
     def setUp(self):
         cache.clear()
-        doctor_group, _ = Group.objects.get_or_create(name="doctor")
+        doctor_group, _ = Group.objects.get_or_create(name="Doctor")
         user = User.objects.create_user(username="docfilter", password="pass")
         user.groups.add(doctor_group)
         token = Token.objects.create(user=user)
@@ -86,9 +86,9 @@ class PatientFilterTests(APITestCase):
 class VisitTests(APITestCase):
     def setUp(self):
         cache.clear()
-        assistant_group, _ = Group.objects.get_or_create(name="assistant")
-        doctor_group, _ = Group.objects.get_or_create(name="doctor")
-        display_group, _ = Group.objects.get_or_create(name="display")
+        assistant_group, _ = Group.objects.get_or_create(name="Assistant")
+        doctor_group, _ = Group.objects.get_or_create(name="Doctor")
+        display_group, _ = Group.objects.get_or_create(name="Display")
 
         self.assistant = User.objects.create_user(username="asst", password="pass")
         self.assistant.groups.add(assistant_group)


### PR DESCRIPTION
## Summary
- make the reusable IsInGroup permission accept seeded group names in a case-insensitive way
- ensure visit list permissions continue to work for Display users with capitalized group names
- update API tests to rely on seeded group fixtures and verify permissions for those roles

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2af6bfffc83239809b561bba808dc