### PR TITLE
Enable role-aware routing and fix patient-facing workflows

### DIFF
--- a/clinicq_frontend/src/App.jsx
+++ b/clinicq_frontend/src/App.jsx
@@ -1,27 +1,100 @@
-import { Routes, Route, Link, useSearchParams } from 'react-router-dom'; // Removed BrowserRouter as Router
-import AssistantPage from './pages/AssistantPage';
-import DoctorPage from './pages/DoctorPage'; // Placeholder for now
-import PublicDisplayPage from './pages/PublicDisplayPage'; // Placeholder for now
-import PatientsPage from './pages/PatientsPage';
-import PatientFormPage from './pages/PatientFormPage';
-import LoginPage from './pages/LoginPage';
-import './App.css'; // Keep or modify as needed
+import { useMemo } from 'react';
+import { Routes, Route, Link, useSearchParams } from 'react-router-dom';
+import AssistantPage from './pages/AssistantPage.jsx';
+import DoctorPage from './pages/DoctorPage.jsx';
+import PublicDisplayPage from './pages/PublicDisplayPage.jsx';
+import PatientsPage from './pages/PatientsPage.jsx';
+import PatientFormPage from './pages/PatientFormPage.jsx';
+import LoginPage from './pages/LoginPage.jsx';
+import UnauthorizedPage from './pages/UnauthorizedPage.jsx';
+import ProtectedRoute from './components/ProtectedRoute.jsx';
+import { useAuth } from './AuthContext.jsx';
+import './App.css';
 
-// Placeholder components
-const HomePage = () => (
-  <div className="container mx-auto p-4">
-    <h1 className="text-3xl font-bold mb-4">ClinicQ</h1>
-    <nav>
-      <ul className="space-y-2">
-        <li><Link to="/assistant" className="text-blue-500 hover:underline">Assistant Portal</Link></li>
-        <li><Link to="/doctor" className="text-blue-500 hover:underline">Doctor Dashboard</Link></li>
-        <li><Link to="/display" className="text-blue-500 hover:underline">Public Queue Display</Link></li>
-        <li><Link to="/patients" className="text-blue-500 hover:underline">Manage Patients</Link></li>
-        <li><Link to="/login" className="text-blue-500 hover:underline">Login</Link></li>
-      </ul>
-    </nav>
-  </div>
-);
+const HomePage = () => {
+  const { roles, username, logout } = useAuth();
+  const normalizedRoles = useMemo(
+    () => roles.map((role) => role.toLowerCase()),
+    [roles],
+  );
+
+  const hasAnyRole = normalizedRoles.length > 0;
+
+  const roleLinks = [
+    { to: '/assistant', label: 'Assistant Portal', role: 'assistant' },
+    { to: '/doctor', label: 'Doctor Dashboard', role: 'doctor' },
+    { to: '/display', label: 'Public Queue Display', role: 'display' },
+    { to: '/patients', label: 'Manage Patients', role: ['assistant', 'doctor'] },
+  ];
+
+  const linkIsVisible = (requiredRole) => {
+    if (!requiredRole) {
+      return true;
+    }
+
+    const targets = Array.isArray(requiredRole) ? requiredRole : [requiredRole];
+    return targets.some((target) => normalizedRoles.includes(target));
+  };
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">ClinicQ</h1>
+          <p className="text-gray-600">Outpatient queue management made simple.</p>
+        </div>
+        <div className="text-right">
+          {username ? (
+            <>
+              <p className="text-sm text-gray-600">Signed in as {username}</p>
+              <button
+                type="button"
+                onClick={logout}
+                className="mt-2 rounded-md border border-red-500 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50"
+              >
+                Log out
+              </button>
+            </>
+          ) : (
+            <Link
+              to="/login"
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+            >
+              Log in
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {!hasAnyRole && (
+        <p className="mb-6 rounded-md bg-blue-50 p-4 text-sm text-blue-700">
+          Sign in with your clinic account to access the queue management tools.
+        </p>
+      )}
+
+      <nav>
+        <ul className="space-y-3">
+          {roleLinks
+            .filter(({ role }) => linkIsVisible(role))
+            .map(({ to, label }) => (
+              <li key={to}>
+                <Link to={to} className="text-blue-600 hover:underline">
+                  {label}
+                </Link>
+              </li>
+            ))}
+          {!username && (
+            <li>
+              <Link to="/login" className="text-blue-600 hover:underline">
+                Login
+              </Link>
+            </li>
+          )}
+        </ul>
+      </nav>
+    </div>
+  );
+};
 
 const PublicDisplayRoute = () => {
   const [searchParams] = useSearchParams();
@@ -29,24 +102,62 @@ const PublicDisplayRoute = () => {
   return <PublicDisplayPage initialQueue={queue} />;
 };
 
-
-function App() {
-  return (
-    // <Router> component removed
-    <div className="min-h-screen bg-gray-100">
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/assistant" element={<AssistantPage />} />
-        <Route path="/doctor" element={<DoctorPage />} />
-        <Route path="/display" element={<PublicDisplayRoute />} />
-        <Route path="/patients" element={<PatientsPage />} />
-        <Route path="/patients/new" element={<PatientFormPage />} />
-        <Route path="/patients/:registration_number/edit" element={<PatientFormPage />} />
-        <Route path="/login" element={<LoginPage />} />
-      </Routes>
-    </div>
-    // </Router> component removed
-  );
-}
+const App = () => (
+  <div className="min-h-screen bg-gray-100">
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route
+        path="/assistant"
+        element={(
+          <ProtectedRoute requiredRoles={['assistant']}>
+            <AssistantPage />
+          </ProtectedRoute>
+        )}
+      />
+      <Route
+        path="/doctor"
+        element={(
+          <ProtectedRoute requiredRoles={['doctor']}>
+            <DoctorPage />
+          </ProtectedRoute>
+        )}
+      />
+      <Route
+        path="/display"
+        element={(
+          <ProtectedRoute requiredRoles={['display', 'doctor']}>
+            <PublicDisplayRoute />
+          </ProtectedRoute>
+        )}
+      />
+      <Route
+        path="/patients"
+        element={(
+          <ProtectedRoute requiredRoles={['assistant', 'doctor']}>
+            <PatientsPage />
+          </ProtectedRoute>
+        )}
+      />
+      <Route
+        path="/patients/new"
+        element={(
+          <ProtectedRoute requiredRoles={['assistant', 'doctor']}>
+            <PatientFormPage />
+          </ProtectedRoute>
+        )}
+      />
+      <Route
+        path="/patients/:registration_number/edit"
+        element={(
+          <ProtectedRoute requiredRoles={['assistant', 'doctor']}>
+            <PatientFormPage />
+          </ProtectedRoute>
+        )}
+      />
+      <Route path="/unauthorized" element={<UnauthorizedPage />} />
+      <Route path="/login" element={<LoginPage />} />
+    </Routes>
+  </div>
+);
 
 export default App;

--- a/clinicq_frontend/src/App.test.jsx
+++ b/clinicq_frontend/src/App.test.jsx
@@ -6,6 +6,7 @@ import App from './App';
 import AssistantPage from './pages/AssistantPage';
 import DoctorPage from './pages/DoctorPage';
 import PublicDisplayPage from './pages/PublicDisplayPage';
+import { AuthProvider } from './AuthContext.jsx';
 import api from './api';
 
 jest.mock('./api');
@@ -70,9 +71,11 @@ describe('Displays last_5_visit_dates', () => {
 
     const user = userEvent.setup();
     render(
-      <MemoryRouter initialEntries={['/assistant']}>
-        <App />
-      </MemoryRouter>
+      <AuthProvider initialState={{ roles: ['Assistant'], username: 'assistant' }}>
+        <MemoryRouter initialEntries={['/assistant']}>
+          <App />
+        </MemoryRouter>
+      </AuthProvider>
     );
 
     const regInput = screen.getByLabelText(/Registration Number/i);
@@ -120,9 +123,11 @@ describe('Displays last_5_visit_dates', () => {
     });
 
     render(
-      <MemoryRouter initialEntries={['/doctor']}>
-        <App />
-      </MemoryRouter>
+      <AuthProvider initialState={{ roles: ['Doctor'], username: 'doctor' }}>
+        <MemoryRouter initialEntries={['/doctor']}>
+          <App />
+        </MemoryRouter>
+      </AuthProvider>
     );
 
     await waitFor(() => {

--- a/clinicq_frontend/src/AuthContext.jsx
+++ b/clinicq_frontend/src/AuthContext.jsx
@@ -1,26 +1,61 @@
-import { createContext, useContext, useState } from 'react';
-import api from './api';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import api, { clearAccessToken } from './api';
 
-const AuthContext = createContext({ roles: [], fetchRoles: async () => {} });
+const defaultContext = {
+  roles: [],
+  username: null,
+  isLoading: false,
+  hasRole: () => false,
+  fetchRoles: async () => {},
+  logout: () => {},
+};
 
-export const AuthProvider = ({ children }) => {
-  const [roles, setRoles] = useState([]);
+const AuthContext = createContext(defaultContext);
 
-  const fetchRoles = async () => {
+export const AuthProvider = ({ children, initialState }) => {
+  const [roles, setRoles] = useState(initialState?.roles ?? []);
+  const [username, setUsername] = useState(initialState?.username ?? null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const resetState = useCallback(() => {
+    setRoles([]);
+    setUsername(null);
+  }, []);
+
+  const fetchRoles = useCallback(async () => {
+    setIsLoading(true);
     try {
       const response = await api.get('/auth/me/');
-      setRoles(response.data.roles || []);
-    } catch {
-      setRoles([]);
+      const payload = response?.data ?? {};
+      setRoles(Array.isArray(payload.roles) ? payload.roles : []);
+      setUsername(payload.username ?? null);
+      return payload;
+    } catch (error) {
+      resetState();
+      throw error;
+    } finally {
+      setIsLoading(false);
     }
-  };
+  }, [resetState]);
 
-  return (
-    <AuthContext.Provider value={{ roles, fetchRoles }}>
-      {children}
-    </AuthContext.Provider>
+  const hasRole = useCallback(
+    (role) => roles.some((current) => current?.toLowerCase() === role?.toLowerCase()),
+    [roles],
   );
+
+  const logout = useCallback(() => {
+    clearAccessToken();
+    resetState();
+  }, [resetState]);
+
+  const value = useMemo(
+    () => ({ roles, username, isLoading, fetchRoles, hasRole, logout }),
+    [roles, username, isLoading, fetchRoles, hasRole, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
 export const useAuth = () => useContext(AuthContext);
 
+export default AuthContext;

--- a/clinicq_frontend/src/components/ProtectedRoute.jsx
+++ b/clinicq_frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../AuthContext.jsx';
+
+const ProtectedRoute = ({ children, requiredRoles = [] }) => {
+  const location = useLocation();
+  const { roles, fetchRoles, isLoading, hasRole } = useAuth();
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const ensureRoles = async () => {
+      try {
+        await fetchRoles();
+      } catch (error) {
+        // The API interceptor handles redirecting on 401s.
+      } finally {
+        if (!cancelled) {
+          setChecked(true);
+        }
+      }
+    };
+
+    if (!checked) {
+      if (roles.length > 0) {
+        setChecked(true);
+      } else {
+        ensureRoles();
+      }
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [checked, fetchRoles, roles.length]);
+
+  if (!checked || isLoading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center text-gray-600">
+        Checking permissions...
+      </div>
+    );
+  }
+
+  if (!roles.length) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  if (
+    requiredRoles.length > 0 &&
+    !requiredRoles.some((role) => hasRole(role))
+  ) {
+    return <Navigate to="/unauthorized" state={{ from: location }} replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/clinicq_frontend/src/pages/DoctorPage.jsx
+++ b/clinicq_frontend/src/pages/DoctorPage.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback } from 'react';
-import api from '../api';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import api from '../api.js';
+import { unwrapListResponse } from '../utils/api.js';
 
 const DoctorPage = () => {
   const [visits, setVisits] = useState([]);
@@ -16,46 +17,55 @@ const DoctorPage = () => {
     try {
       const queueParam = selectedQueue ? `&queue=${selectedQueue}` : '';
       const response = await api.get(`/visits/?status=WAITING,START,IN_ROOM${queueParam}`);
-      const fetchedVisits = response.data || [];
+      const fetchedVisits = unwrapListResponse(response.data);
 
       const registrationNumbers = [
-        ...new Set(fetchedVisits.map((v) => v.patient_registration_number)),
+        ...new Set(
+          fetchedVisits
+            .map((visit) => visit.patient_registration_number)
+            .filter(Boolean)
+            .map((value) => String(value)),
+        ),
       ];
-      let patientsByRegNum = {};
 
+      let patientsByRegNum = {};
       if (registrationNumbers.length > 0) {
-        // This logic can be simplified if the backend provides patient details directly
         const patientsResp = await api.get(
-          `/patients/?registration_numbers=${registrationNumbers.join(',')}`
+          `/patients/?registration_numbers=${registrationNumbers.join(',')}`,
         );
-        patientsByRegNum = (patientsResp.data || []).reduce((acc, patient) => {
-          acc[patient.registration_number] = patient;
+        const patientList = unwrapListResponse(patientsResp.data);
+        patientsByRegNum = patientList.reduce((acc, patient) => {
+          if (patient?.registration_number !== undefined) {
+            acc[String(patient.registration_number)] = patient;
+          }
           return acc;
         }, {});
       }
 
       const detailedVisits = fetchedVisits.map((visit) => ({
         ...visit,
-        patient_details: patientsByRegNum[visit.patient_registration_number] || null,
+        patient_details:
+          patientsByRegNum[String(visit.patient_registration_number)] ?? null,
       }));
 
       let withImages = detailedVisits;
       if (import.meta.env.MODE !== 'test') {
         withImages = await Promise.all(
-          detailedVisits.map(async (v) => {
+          detailedVisits.map(async (visit) => {
             try {
-              const imgResp = await api.get(`/prescriptions/?visit=${v.id}`);
-              return { ...v, prescription_images: imgResp.data || [] };
-            } catch {
-              return { ...v, prescription_images: [] };
+              const imgResp = await api.get(`/prescriptions/?visit=${visit.id}`);
+              return { ...visit, prescription_images: unwrapListResponse(imgResp.data) };
+            } catch (imageError) {
+              console.error('Failed to fetch prescription images:', imageError);
+              return { ...visit, prescription_images: [] };
             }
-          })
+          }),
         );
       }
 
       setVisits(withImages);
     } catch (err) {
-      console.error("Error fetching visits:", err);
+      console.error('Error fetching visits:', err);
       setError('Failed to fetch visits. Please try again.');
     } finally {
       setIsLoading(false);
@@ -67,7 +77,7 @@ const DoctorPage = () => {
     const fetchQueues = async () => {
       try {
         const response = await api.get('/queues/');
-        setQueues(response.data || []);
+        setQueues(Array.isArray(response.data) ? response.data : []);
       } catch (err) {
         console.error('Error fetching queues:', err);
       }
@@ -82,7 +92,7 @@ const DoctorPage = () => {
   const handleUpdateVisitStatus = async (visitId, action) => {
     try {
       await api.patch(`/visits/${visitId}/${action}/`);
-      fetchVisits(); // Refetch to get the latest state
+      fetchVisits();
     } catch (err) {
       console.error(`Error during action ${action} for visit ${visitId}:`, err);
       setError(`Failed to perform action. ${err.response?.data?.detail || ''}`);
@@ -110,11 +120,11 @@ const DoctorPage = () => {
       await api.post('/prescriptions/', form);
       const imgResp = await api.get(`/prescriptions/?visit=${visitId}`);
       setVisits((prev) =>
-        prev.map((v) =>
-          v.id === visitId
-            ? { ...v, prescription_images: imgResp.data || [] }
-            : v
-        )
+        prev.map((visit) =>
+          visit.id === visitId
+            ? { ...visit, prescription_images: unwrapListResponse(imgResp.data) }
+            : visit,
+        ),
       );
       setUploadStates((prev) => ({
         ...prev,
@@ -129,7 +139,7 @@ const DoctorPage = () => {
     }
   };
 
-  const renderActionButtons = (visit) => {
+  const renderActionButtons = useCallback((visit) => {
     switch (visit.status) {
       case 'WAITING':
         return (
@@ -177,7 +187,16 @@ const DoctorPage = () => {
       default:
         return null;
     }
-  };
+  }, [handleUpdateVisitStatus]);
+
+  const normalizedVisits = useMemo(
+    () =>
+      visits.map((visit) => ({
+        ...visit,
+        prescription_images: visit.prescription_images || [],
+      })),
+    [visits],
+  );
 
   return (
     <div className="container mx-auto p-6 bg-white shadow-md rounded-lg mt-10">
@@ -204,20 +223,23 @@ const DoctorPage = () => {
       </div>
 
       {isLoading && <p className="text-center text-gray-500">Loading patient list...</p>}
-      {error && <p className="text-red-500 text-sm bg-red-100 p-3 rounded-md mb-4">{error}</p>}
+      {error && <p className="text-red-500 text-sm bg-red-100 p-3 rounded-md mb-4" role="alert">{error}</p>}
 
-      {!isLoading && visits.length === 0 && !error && (
+      {!isLoading && normalizedVisits.length === 0 && !error && (
         <p className="text-center text-gray-600 py-4">No active patients.</p>
       )}
 
-      {visits.length > 0 && (
+      {normalizedVisits.length > 0 && (
         <div className="space-y-4">
-          {visits.map((visit) => (
+          {normalizedVisits.map((visit) => (
             <div
               key={visit.id}
               className={`p-4 border rounded-lg shadow-sm flex justify-between items-center ${
-                visit.status === 'IN_ROOM' ? 'bg-purple-50 border-purple-300' :
-                visit.status === 'START' ? 'bg-blue-50 border-blue-300' : 'bg-gray-50'
+                visit.status === 'IN_ROOM'
+                  ? 'bg-purple-50 border-purple-300'
+                  : visit.status === 'START'
+                    ? 'bg-blue-50 border-blue-300'
+                    : 'bg-gray-50'
               }`}
             >
               <div>
@@ -236,9 +258,42 @@ const DoctorPage = () => {
                     ? visit.patient_details.last_5_visit_dates.join(', ')
                     : 'None'}
                 </p>
+                {visit.prescription_images.length > 0 && (
+                  <div className="mt-2 flex space-x-2">
+                    {visit.prescription_images.map((img) => (
+                      <a
+                        key={img.id}
+                        href={img.image_url}
+                        className="text-xs text-blue-600 hover:underline"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        View Prescription
+                      </a>
+                    ))}
+                  </div>
+                )}
               </div>
               <div className="flex flex-col items-end space-y-2">
                 {renderActionButtons(visit)}
+                <div className="flex flex-col items-end space-y-2">
+                  <input
+                    type="file"
+                    onChange={(e) => handleFileChange(visit.id, e.target.files?.[0] ?? null)}
+                    className="text-sm"
+                  />
+                  <button
+                    type="button"
+                    disabled={!uploadStates[visit.id]?.file || uploadStates[visit.id]?.uploading}
+                    onClick={() => handleUpload(visit.id)}
+                    className="px-3 py-1 bg-indigo-600 text-white rounded disabled:bg-gray-400"
+                  >
+                    {uploadStates[visit.id]?.uploading ? 'Uploading...' : 'Upload Prescription'}
+                  </button>
+                  {uploadStates[visit.id]?.error && (
+                    <span className="text-xs text-red-500">{uploadStates[visit.id].error}</span>
+                  )}
+                </div>
               </div>
             </div>
           ))}

--- a/clinicq_frontend/src/pages/PatientsPage.jsx
+++ b/clinicq_frontend/src/pages/PatientsPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-import api from '../api';
 import { Link, useNavigate } from 'react-router-dom';
+import api from '../api.js';
+import { unwrapListResponse } from '../utils/api.js';
 
 const PatientsPage = () => {
   const [patients, setPatients] = useState([]);
@@ -18,7 +19,7 @@ const PatientsPage = () => {
         url = `/patients/search/?q=${encodeURIComponent(term.trim())}`;
       }
       const response = await api.get(url);
-      setPatients(response.data);
+      setPatients(unwrapListResponse(response.data));
     } catch (err) {
       console.error('Failed to fetch patients', err);
       setError('Failed to fetch patients');
@@ -35,7 +36,7 @@ const PatientsPage = () => {
     if (!window.confirm('Are you sure you want to delete this patient?')) return;
     try {
       await api.delete(`/patients/${regNum}/`);
-      setPatients((prev) => prev.filter((p) => p.registration_number !== regNum));
+      setPatients((prev) => prev.filter((patient) => patient.registration_number !== regNum));
     } catch (err) {
       console.error('Delete failed', err);
       setError('Failed to delete patient');
@@ -50,7 +51,7 @@ const PatientsPage = () => {
   return (
     <div className="container mx-auto p-6">
       <Link to="/" className="text-blue-500 hover:underline">&larr; Back to Home</Link>
-      <div className="flex justify-between items-center mt-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 mt-4">
         <h1 className="text-2xl font-bold">Patients</h1>
         <button
           onClick={() => navigate('/patients/new')}
@@ -60,7 +61,7 @@ const PatientsPage = () => {
         </button>
       </div>
 
-      <form onSubmit={handleSearch} className="mt-4 flex space-x-2">
+      <form onSubmit={handleSearch} className="mt-4 flex flex-wrap gap-2">
         <input
           type="text"
           placeholder="Search by name, phone, or ID"
@@ -74,43 +75,45 @@ const PatientsPage = () => {
       {loading ? (
         <p className="mt-4">Loading...</p>
       ) : error ? (
-        <p className="mt-4 text-red-600">{error}</p>
+        <p className="mt-4 text-red-600" role="alert">{error}</p>
       ) : (
-        <table className="min-w-full mt-6 bg-white shadow-md rounded">
-          <thead>
-            <tr className="bg-gray-100 text-left">
-              <th className="p-2">Reg. No.</th>
-              <th className="p-2">Name</th>
-              <th className="p-2">Gender</th>
-              <th className="p-2">Phone</th>
-              <th className="p-2">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {patients.map((p) => (
-              <tr key={p.registration_number} className="border-t">
-                <td className="p-2">{p.registration_number}</td>
-                <td className="p-2">{p.name}</td>
-                <td className="p-2">{p.gender}</td>
-                <td className="p-2">{p.phone || '-'}</td>
-                <td className="p-2 space-x-2">
-                  <button
-                    onClick={() => navigate(`/patients/${p.registration_number}/edit`)}
-                    className="px-3 py-1 bg-yellow-500 text-white rounded hover:bg-yellow-600"
-                  >
-                    Edit
-                  </button>
-                  <button
-                    onClick={() => handleDelete(p.registration_number)}
-                    className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700"
-                  >
-                    Delete
-                  </button>
-                </td>
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full bg-white shadow-md rounded">
+            <thead>
+              <tr className="bg-gray-100 text-left">
+                <th className="p-2">Reg. No.</th>
+                <th className="p-2">Name</th>
+                <th className="p-2">Gender</th>
+                <th className="p-2">Phone</th>
+                <th className="p-2">Actions</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {patients.map((patient) => (
+                <tr key={patient.registration_number} className="border-t">
+                  <td className="p-2">{patient.registration_number}</td>
+                  <td className="p-2">{patient.name}</td>
+                  <td className="p-2">{patient.gender}</td>
+                  <td className="p-2">{patient.phone || '-'}</td>
+                  <td className="p-2 space-x-2">
+                    <button
+                      onClick={() => navigate(`/patients/${patient.registration_number}/edit`)}
+                      className="px-3 py-1 bg-yellow-500 text-white rounded hover:bg-yellow-600"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleDelete(patient.registration_number)}
+                      className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/clinicq_frontend/src/pages/UnauthorizedPage.jsx
+++ b/clinicq_frontend/src/pages/UnauthorizedPage.jsx
@@ -1,0 +1,28 @@
+import { Link, useLocation } from 'react-router-dom';
+
+const UnauthorizedPage = () => {
+  const location = useLocation();
+  const from = location.state?.from?.pathname;
+
+  return (
+    <div className="container mx-auto max-w-xl p-8 text-center">
+      <h1 className="text-3xl font-bold text-red-600">Access denied</h1>
+      <p className="mt-4 text-gray-700">
+        You do not have permission to view this page. Please contact an administrator if you believe this is a mistake.
+      </p>
+      {from && (
+        <p className="mt-2 text-sm text-gray-500">Attempted destination: {from}</p>
+      )}
+      <div className="mt-6 flex justify-center space-x-4">
+        <Link to="/" className="text-blue-600 hover:underline">
+          Go to home
+        </Link>
+        <Link to="/login" className="text-blue-600 hover:underline">
+          Log in with a different account
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default UnauthorizedPage;

--- a/clinicq_frontend/src/utils/api.js
+++ b/clinicq_frontend/src/utils/api.js
@@ -1,0 +1,16 @@
+export const unwrapListResponse = (payload) => {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (payload && Array.isArray(payload.results)) {
+    return payload.results;
+  }
+
+  return [];
+};
+
+export const firstFromListResponse = (payload) => {
+  const [first] = unwrapListResponse(payload);
+  return first ?? null;
+};

--- a/clinicq_frontend/src/utils/api.test.js
+++ b/clinicq_frontend/src/utils/api.test.js
@@ -1,0 +1,32 @@
+import { firstFromListResponse, unwrapListResponse } from './api';
+
+describe('unwrapListResponse', () => {
+  it('returns the payload when it is already an array', () => {
+    expect(unwrapListResponse([1, 2])).toEqual([1, 2]);
+  });
+
+  it('returns results when payload contains a paginated structure', () => {
+    expect(unwrapListResponse({ results: ['a', 'b'] })).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array for unsupported payloads', () => {
+    expect(unwrapListResponse(null)).toEqual([]);
+    expect(unwrapListResponse({})).toEqual([]);
+  });
+});
+
+describe('firstFromListResponse', () => {
+  it('returns the first item from an array payload', () => {
+    expect(firstFromListResponse([3, 4])).toBe(3);
+  });
+
+  it('returns the first item from a paginated payload', () => {
+    expect(firstFromListResponse({ results: ['x', 'y'] })).toBe('x');
+  });
+
+  it('returns null when the payload has no items', () => {
+    expect(firstFromListResponse([])).toBeNull();
+    expect(firstFromListResponse({ results: [] })).toBeNull();
+    expect(firstFromListResponse(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add role-aware auth context, protected routes, and an unauthorized screen to gate pages by clinic role
- improve the login experience and home navigation with redirects, logout, and role-aware links
- normalize assistant, doctor, and patient management flows to work with paginated API responses and current backend fields
- add shared utilities and tests for handling paginated API payloads

## Testing
- `npm test -- --watch=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d474a6be9c8323aa504c665c59ec11