### PR TITLE
Fix patient list handling for paginated responses

### DIFF
--- a/clinicq_frontend/src/__tests__/PatientsPage.test.jsx
+++ b/clinicq_frontend/src/__tests__/PatientsPage.test.jsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import PatientsPage from '../pages/PatientsPage';
+import api from '../api';
+
+jest.mock('../api');
+
+describe('PatientsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders patients from paginated responses', async () => {
+    api.get.mockResolvedValueOnce({
+      data: {
+        results: [
+          {
+            registration_number: 101,
+            name: 'John Doe',
+            gender: 'MALE',
+            phone: '555-1234',
+          },
+        ],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <PatientsPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('555-1234')).toBeInTheDocument();
+  });
+
+  test('renders patients from array responses (search)', async () => {
+    api.get
+      .mockResolvedValueOnce({ data: { results: [] } })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            registration_number: 303,
+            name: 'Jane Roe',
+            gender: 'FEMALE',
+            phone: null,
+          },
+        ],
+      });
+
+    render(
+      <MemoryRouter>
+        <PatientsPage />
+      </MemoryRouter>
+    );
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByPlaceholderText(/search by name, phone, or id/i),
+      'Jane'
+    );
+    await user.click(screen.getByRole('button', { name: /search/i }));
+
+    expect(await screen.findByText('Jane Roe')).toBeInTheDocument();
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+});

--- a/clinicq_frontend/src/pages/PatientsPage.jsx
+++ b/clinicq_frontend/src/pages/PatientsPage.jsx
@@ -2,6 +2,18 @@ import { useEffect, useState } from 'react';
 import api from '../api';
 import { Link, useNavigate } from 'react-router-dom';
 
+const normalizePatientsPayload = (payload) => {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (payload && Array.isArray(payload.results)) {
+    return payload.results;
+  }
+
+  return [];
+};
+
 const PatientsPage = () => {
   const [patients, setPatients] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -18,7 +30,7 @@ const PatientsPage = () => {
         url = `/patients/search/?q=${encodeURIComponent(term.trim())}`;
       }
       const response = await api.get(url);
-      setPatients(response.data);
+      setPatients(normalizePatientsPayload(response.data));
     } catch (err) {
       console.error('Failed to fetch patients', err);
       setError('Failed to fetch patients');


### PR DESCRIPTION
## Summary
- normalize the Patients page API handling so it works with paginated and array responses
- add regression tests covering both paginated and search responses

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d2b87b2adc8323a5773ce89bed7dd8