### PR TITLE
Polish frontend styling and documentation for deployment

### DIFF
--- a/clinicq_frontend/README.md
+++ b/clinicq_frontend/README.md
@@ -1,12 +1,98 @@
-# React + Vite
+# ClinicQ Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A React + Vite single-page application for managing outpatient queues, patient intake, and doctor workflows at the ClinicQ facility. The UI ships with role-aware routing, authenticated dashboards for assistants and doctors, a large-screen public display, and patient administration tooling.
 
-Currently, two official plugins are available:
+## Key features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- **Role-based navigation** – Centralized auth context fetches the active session, caches roles, and guards assistant, doctor, display, and patient management routes.
+- **Assistant portal** – Offers queue selection, debounced patient lookup, visit creation, and clear feedback messaging for generated tokens.
+- **Doctor dashboard** – Surfaces visits by queue, allows status transitions, and links directly to patient context and prescription management.
+- **Public queue display** – Provides a kiosk-friendly auto-refreshing view of waiting and in-consultation tokens with configurable queue filters.
+- **Patient management** – Includes a searchable patient table, create/edit form with validation, and visit history context.
+- **Resilient API client** – Axios wrapper normalizes base URLs, injects auth headers, and gracefully redirects to login on 401s.
+- **Production-ready telemetry hook** – Optional Sentry DSN bootstraps runtime error collection without code changes.
 
-## Expanding the ESLint configuration
+## Technology stack
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+- **Framework:** React 19 with React Router 7
+- **Build tooling:** Vite 7, Babel, Jest, and Testing Library
+- **Styling:** Tailwind CSS utilities supplemented by a small amount of global CSS
+- **Quality:** ESLint with React and hooks plugins, Jest + Testing Library for unit and integration coverage
+
+## Project structure
+
+```
+clinicq_frontend/
+├── index.html           # Base HTML template and metadata
+├── src/
+│   ├── App.jsx          # Route definitions and landing page
+│   ├── AuthContext.jsx  # Session/role state provider
+│   ├── api.js           # Axios instance and token helpers
+│   ├── pages/           # Feature screens (assistant, doctor, display, patients, auth)
+│   ├── components/      # Shared UI elements (protected routes, tables, forms)
+│   ├── utils/           # API helpers and shared utilities
+│   └── assets/          # Static assets loaded by the bundle
+├── public/              # Static assets served as-is (favicon, etc.)
+└── package.json         # Scripts, dependencies, and tooling configuration
+```
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 20+
+- npm 10+
+- A running ClinicQ backend API (see `docker-compose.yml` or backend documentation)
+
+### Installation
+
+```bash
+cd clinicq_frontend
+npm install
+```
+
+### Environment configuration
+
+Create a `.env` file (or copy `ENV.sample`) alongside `package.json` and configure the following variables as needed:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `VITE_API_BASE_URL` | Base URL of the ClinicQ backend. A trailing `/api` segment is appended automatically when missing. | `/api` |
+| `VITE_SENTRY_DSN` | Optional Sentry DSN for client-side error reporting. | _unset_ |
+
+### Development server
+
+```bash
+npm run dev
+```
+
+The application is served with hot module reloading at [http://localhost:5173](http://localhost:5173). API requests are proxied to the URL defined by `VITE_API_BASE_URL`.
+
+### Linting and tests
+
+```bash
+npm run lint   # Static analysis
+npm run test   # Jest + Testing Library suite
+```
+
+Both commands are executed in CI; run them locally before opening a pull request.
+
+### Production build
+
+```bash
+npm run build
+```
+
+Vite outputs the static build to `dist/`. Preview the production bundle locally with `npm run preview`.
+
+## Styling guidelines
+
+- Tailwind utility classes handle component-level layout and theming.
+- Global styles in `src/index.css` set consistent typography, colors, and link states for the entire SPA.
+- Additional component-specific styles should prefer Tailwind utilities; use CSS modules or scoped styles only when necessary.
+
+## Deployment notes
+
+- The frontend expects the backend to expose `/auth/me/`, `/auth/login/`, `/auth/logout/`, `/visits/`, `/queues/`, and `/patients/` endpoints.
+- Set `VITE_API_BASE_URL` to the externally reachable backend URL before building for production.
+- Provide a valid `VITE_SENTRY_DSN` in production environments to capture runtime errors.

--- a/clinicq_frontend/eslint.config.js
+++ b/clinicq_frontend/eslint.config.js
@@ -38,4 +38,13 @@ export default defineConfig([
       },
     },
   },
+  {
+    files: ['src/__mocks__/**/*.{js,jsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+    },
+  },
 ])

--- a/clinicq_frontend/index.html
+++ b/clinicq_frontend/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <meta
+      name="description"
+      content="ClinicQ frontend for managing outpatient queues, patient intake, and doctor workflows."
+    />
+    <title>ClinicQ | Queue Management Platform</title>
   </head>
   <body>
     <div id="root"></div>

--- a/clinicq_frontend/src/App.css
+++ b/clinicq_frontend/src/App.css
@@ -1,42 +1,9 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+main {
+  flex: 1;
 }

--- a/clinicq_frontend/src/AuthContext.jsx
+++ b/clinicq_frontend/src/AuthContext.jsx
@@ -56,6 +56,8 @@ export const AuthProvider = ({ children, initialState }) => {
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
+// Hooks exported alongside components trigger the react-refresh guard; document the intent explicitly.
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => useContext(AuthContext);
 
 export default AuthContext;

--- a/clinicq_frontend/src/api.js
+++ b/clinicq_frontend/src/api.js
@@ -30,15 +30,6 @@ const normalizeApiBase = (value) => {
 
 const API_BASE_URL = normalizeApiBase(import.meta.env.VITE_API_BASE_URL);
 
-const buildApiUrl = (path = '') => {
-  if (!path) {
-    return API_BASE_URL;
-  }
-
-  const normalizedPath = path.replace(/^\/+/, '');
-  return `${API_BASE_URL}/${normalizedPath}`;
-};
-
 export const setAccessToken = (token) => {
   accessToken = token;
   redirectingToLogin = false;

--- a/clinicq_frontend/src/components/ProtectedRoute.jsx
+++ b/clinicq_frontend/src/components/ProtectedRoute.jsx
@@ -13,7 +13,7 @@ const ProtectedRoute = ({ children, requiredRoles = [] }) => {
     const ensureRoles = async () => {
       try {
         await fetchRoles();
-      } catch (error) {
+      } catch {
         // The API interceptor handles redirecting on 401s.
       } finally {
         if (!cancelled) {

--- a/clinicq_frontend/src/index.css
+++ b/clinicq_frontend/src/index.css
@@ -3,70 +3,32 @@
 @tailwind utilities;
 
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  color-scheme: light;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
+@layer base {
+  html {
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+    scroll-behavior: smooth;
   }
+
+  body {
+    @apply m-0 min-h-screen bg-slate-50 text-slate-900 antialiased;
+  }
+
+  #root {
+    min-height: 100vh;
+  }
+
+  a {
+    @apply text-indigo-600 underline-offset-4 transition-colors duration-150 ease-in-out;
+  }
+
   a:hover {
-    color: #747bff;
+    @apply text-indigo-700;
   }
-  button {
-    background-color: #f9f9f9;
+
+  button, input, textarea, select {
+    font: inherit;
   }
 }

--- a/clinicq_frontend/src/pages/DoctorPage.jsx
+++ b/clinicq_frontend/src/pages/DoctorPage.jsx
@@ -89,15 +89,18 @@ const DoctorPage = () => {
     fetchVisits();
   }, [fetchVisits]);
 
-  const handleUpdateVisitStatus = async (visitId, action) => {
-    try {
-      await api.patch(`/visits/${visitId}/${action}/`);
-      fetchVisits();
-    } catch (err) {
-      console.error(`Error during action ${action} for visit ${visitId}:`, err);
-      setError(`Failed to perform action. ${err.response?.data?.detail || ''}`);
-    }
-  };
+  const handleUpdateVisitStatus = useCallback(
+    async (visitId, action) => {
+      try {
+        await api.patch(`/visits/${visitId}/${action}/`);
+        fetchVisits();
+      } catch (err) {
+        console.error(`Error during action ${action} for visit ${visitId}:`, err);
+        setError(`Failed to perform action. ${err.response?.data?.detail || ''}`);
+      }
+    },
+    [fetchVisits],
+  );
 
   const handleFileChange = (visitId, file) => {
     setUploadStates((prev) => ({


### PR DESCRIPTION
## Summary
- replace the template README with ClinicQ-specific overview, setup, and deployment guidance
- refresh global styling and HTML metadata to align with the Tailwind-driven layout and ClinicQ branding
- tighten lint configuration and minor code fixes so the React build passes cleanly for deployment

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d581878e0083239e0963daef578236