### PR TITLE
Run Black to clean up whitespace in backend modules

### DIFF
--- a/clinicq_backend/api/migrations/0002_queue_alter_visit_options_patient_visit_patient_and_more.py
+++ b/clinicq_backend/api/migrations/0002_queue_alter_visit_options_patient_visit_patient_and_more.py
@@ -40,10 +40,7 @@ class Migration(migrations.Migration):
                     models.AutoField(primary_key=True, serialize=False),
                 ),
                 ("name", models.CharField(max_length=255)),
-                (
-                    "phone",
-                    models.CharField(blank=True, max_length=20, null=True)
-                ),
+                ("phone", models.CharField(blank=True, max_length=20, null=True)),
                 (
                     "gender",
                     models.CharField(
@@ -61,12 +58,8 @@ class Migration(migrations.Migration):
             ],
             options={
                 "indexes": [
-                    models.Index(
-                        fields=["phone"], name="api_patient_phone_9d1c6b_idx"
-                    ),
-                    models.Index(
-                        fields=["name"], name="api_patient_name_8aa05a_idx"
-                    ),
+                    models.Index(fields=["phone"], name="api_patient_phone_9d1c6b_idx"),
+                    models.Index(fields=["name"], name="api_patient_name_8aa05a_idx"),
                 ],
             },
         ),

--- a/clinicq_backend/api/migrations/0005_prescriptionimage.py
+++ b/clinicq_backend/api/migrations/0005_prescriptionimage.py
@@ -23,10 +23,7 @@ class Migration(migrations.Migration):
                         verbose_name="ID",
                     ),
                 ),
-                (
-                    "drive_file_id",
-                    models.CharField(blank=True, max_length=255)
-                ),
+                ("drive_file_id", models.CharField(blank=True, max_length=255)),
                 ("image_url", models.URLField(blank=True)),
                 ("created_at", models.DateTimeField(auto_now_add=True)),
                 (

--- a/clinicq_backend/api/migrations/0007_auto_20250912_1117.py
+++ b/clinicq_backend/api/migrations/0007_auto_20250912_1117.py
@@ -9,9 +9,7 @@ def create_groups(apps, schema_editor):
 
     for group_name in canonical_groups:
         existing_group = (
-            Group.objects.filter(name__iexact=group_name)
-            .order_by("id")
-            .first()
+            Group.objects.filter(name__iexact=group_name).order_by("id").first()
         )
         if existing_group:
             if existing_group.name != group_name:

--- a/clinicq_backend/api/models.py
+++ b/clinicq_backend/api/models.py
@@ -7,9 +7,9 @@ import re
 
 def validate_registration_number_format(value):
     """Validate that registration number follows xx-xx-xxx format"""
-    if not re.match(r'^\d{2}-\d{2}-\d{3}$', value):
+    if not re.match(r"^\d{2}-\d{2}-\d{3}$", value):
         raise ValidationError(
-            'Registration number must be in format xx-xx-xxx (e.g., 01-23-456)'
+            "Registration number must be in format xx-xx-xxx (e.g., 01-23-456)"
         )
 
 
@@ -57,8 +57,7 @@ class Visit(models.Model):
 
     def __str__(self):
         return (
-            f"Token {self.token_number} - {self.patient.name} "
-            f"({self.visit_date})"
+            f"Token {self.token_number} - {self.patient.name} " f"({self.visit_date})"
         )
 
 
@@ -69,7 +68,7 @@ class Patient(models.Model):
         max_length=8,
         primary_key=True,
         unique=True,
-        validators=[validate_registration_number_format]
+        validators=[validate_registration_number_format],
     )
     name = models.CharField(max_length=255)
     phone = models.CharField(
@@ -89,14 +88,14 @@ class Patient(models.Model):
     def generate_next_registration_number(cls):
         """Generate the next registration number in xx-xx-xxx format"""
         # Get the highest existing registration number
-        last_patient = cls.objects.order_by('-registration_number').first()
+        last_patient = cls.objects.order_by("-registration_number").first()
 
         if not last_patient:
             # First patient gets 01-00-001
             return "01-00-001"
 
         # Extract numeric value from existing format (remove dashes)
-        last_number_str = last_patient.registration_number.replace('-', '')
+        last_number_str = last_patient.registration_number.replace("-", "")
         last_number = int(last_number_str)
 
         # Increment and format as xx-xx-xxx

--- a/clinicq_backend/api/permissions.py
+++ b/clinicq_backend/api/permissions.py
@@ -10,9 +10,7 @@ class IsInGroup(permissions.BasePermission):
         return bool(
             request.user
             and request.user.is_authenticated
-            and request.user.groups.filter(
-                name__iexact=self.group_name
-            ).exists()
+            and request.user.groups.filter(name__iexact=self.group_name).exists()
         )
 
 

--- a/clinicq_backend/api/serializers.py
+++ b/clinicq_backend/api/serializers.py
@@ -19,9 +19,9 @@ class PatientSerializer(serializers.ModelSerializer):
         read_only_fields = ["registration_number", "created_at", "updated_at"]
 
     def get_last_5_visit_dates(self, obj):
-        return obj.visits.order_by("-visit_date").values_list(
-            "visit_date", flat=True
-        )[:5]
+        return obj.visits.order_by("-visit_date").values_list("visit_date", flat=True)[
+            :5
+        ]
 
 
 class QueueSerializer(serializers.ModelSerializer):

--- a/clinicq_backend/api/test_api.py
+++ b/clinicq_backend/api/test_api.py
@@ -43,11 +43,7 @@ class PatientAPITests(APITestCase):
 
     def test_create_patient(self):
         url = reverse("patient-list")
-        data = {
-            "name": "Charlie Brown",
-            "phone": "1122334455",
-            "gender": "MALE"
-        }
+        data = {"name": "Charlie Brown", "phone": "1122334455", "gender": "MALE"}
         response = self.client.post(url, data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
         assert Patient.objects.count() == 3
@@ -85,13 +81,9 @@ class PatientAPITests(APITestCase):
             f"{self.patient1.registration_number}, abc ,"
             f"{self.patient2.registration_number},xyz"
         )
-        response = self.client.get(
-            url, {"registration_numbers": query}, format="json"
-        )
+        response = self.client.get(url, {"registration_numbers": query}, format="json")
         assert response.status_code == status.HTTP_200_OK
-        numbers = [
-            p["registration_number"] for p in response.data["results"]
-        ]
+        numbers = [p["registration_number"] for p in response.data["results"]]
         assert sorted(numbers) == sorted(
             [
                 self.patient1.registration_number,
@@ -178,16 +170,14 @@ class PatientAPITests(APITestCase):
 
     def test_search_patient_by_name_fragment(self):
         url = reverse("patient-search")
-        response = self.client.get(
-            url, {"q": "Alice"}, format="json")  # Partial name
+        response = self.client.get(url, {"q": "Alice"}, format="json")  # Partial name
         assert response.status_code == status.HTTP_200_OK
         assert response.data["count"] == 1
         assert response.data["results"][0]["name"] == self.patient1.name
 
     def test_search_patient_by_phone_fragment(self):
         url = reverse("patient-search")
-        response = self.client.get(
-            url, {"q": "12345"}, format="json")  # Partial phone
+        response = self.client.get(url, {"q": "12345"}, format="json")  # Partial phone
         assert response.status_code == status.HTTP_200_OK
         assert response.data["count"] == 1
         assert response.data["results"][0]["name"] == self.patient1.name
@@ -230,9 +220,7 @@ class PatientAPITests(APITestCase):
         response = self.client.get(url, format="json")
         assert response.status_code == status.HTTP_200_OK
         assert "last_5_visit_dates" in response.data
-        api_visit_dates_iso = [
-            str(d) for d in response.data["last_5_visit_dates"]
-        ]
+        api_visit_dates_iso = [str(d) for d in response.data["last_5_visit_dates"]]
         assert len(api_visit_dates_iso) == 5
 
         # Dates should be most recent 5. SerializerMethodField doesn't
@@ -241,8 +229,7 @@ class PatientAPITests(APITestCase):
         # `obj.visits.order_by('-visit_date').values_list('visit_date',
         # flat=True)[:5]`
         # This means they are already sorted from most recent to oldest.
-        expected_dates_iso = [
-            str(date.today() - timedelta(days=i)) for i in range(5)]
+        expected_dates_iso = [str(date.today() - timedelta(days=i)) for i in range(5)]
         assert api_visit_dates_iso == expected_dates_iso
 
 
@@ -252,8 +239,7 @@ class QueueAPITests(APITestCase):
         cache.clear()
         doctor_group, _ = Group.objects.get_or_create(name="Doctor")
         assistant_group, _ = Group.objects.get_or_create(name="Assistant")
-        user = User.objects.create_user(
-            username="queue_tester", password="pass")
+        user = User.objects.create_user(username="queue_tester", password="pass")
         user.groups.add(doctor_group, assistant_group)
         token = Token.objects.create(user=user)
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
@@ -285,8 +271,7 @@ class VisitAPITests(APITestCase):
         cache.clear()
         doctor_group, _ = Group.objects.get_or_create(name="Doctor")
         assistant_group, _ = Group.objects.get_or_create(name="Assistant")
-        user = User.objects.create_user(
-            username="visit_tester", password="pass")
+        user = User.objects.create_user(username="visit_tester", password="pass")
         user.groups.add(doctor_group, assistant_group)
         token = Token.objects.create(user=user)
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
@@ -305,8 +290,7 @@ class VisitAPITests(APITestCase):
     def test_create_visit_api(self):
         """Test POST /api/visits/ for creating a new visit with patient and queue."""
         url = reverse("visit-list")
-        data = {"patient": self.patient.registration_number,
-                "queue": self.queue1.pk}
+        data = {"patient": self.patient.registration_number, "queue": self.queue1.pk}
 
         response = self.client.post(url, data, format="json")
 
@@ -321,12 +305,9 @@ class VisitAPITests(APITestCase):
 
     def test_create_multiple_visits_same_queue_increments_token(self):
         url = reverse("visit-list")
-        patient2 = Patient.objects.create(
-            name="Another Patient", gender="MALE")
-        data1 = {"patient": self.patient.registration_number,
-                 "queue": self.queue1.pk}
-        data2 = {"patient": patient2.registration_number,
-                 "queue": self.queue1.pk}
+        patient2 = Patient.objects.create(name="Another Patient", gender="MALE")
+        data1 = {"patient": self.patient.registration_number, "queue": self.queue1.pk}
+        data2 = {"patient": patient2.registration_number, "queue": self.queue1.pk}
 
         response1 = self.client.post(url, data1, format="json")
         assert response1.status_code == status.HTTP_201_CREATED
@@ -340,8 +321,7 @@ class VisitAPITests(APITestCase):
     def test_multi_queue_token_independence(self):
         """Test tokens are independent across different queues on the same day."""
         url = reverse("visit-list")
-        patient2 = Patient.objects.create(
-            name="Patient Two QTwo", gender="FEMALE")
+        patient2 = Patient.objects.create(name="Patient Two QTwo", gender="FEMALE")
 
         # Visit in Queue 1
         data_q1_v1 = {
@@ -354,8 +334,7 @@ class VisitAPITests(APITestCase):
         assert response_q1_v1.data["queue_name"] == self.queue1.name
 
         # Visit in Queue 2 - token should also be 1
-        data_q2_v1 = {"patient": patient2.registration_number,
-                      "queue": self.queue2.pk}
+        data_q2_v1 = {"patient": patient2.registration_number, "queue": self.queue2.pk}
         response_q2_v1 = self.client.post(url, data_q2_v1, format="json")
         assert response_q2_v1.status_code == status.HTTP_201_CREATED
         # Independent token for Queue 2
@@ -363,10 +342,8 @@ class VisitAPITests(APITestCase):
         assert response_q2_v1.data["queue_name"] == self.queue2.name
 
         # Another visit in Queue 1 - token should be 2
-        patient3 = Patient.objects.create(
-            name="Patient Three QOne", gender="OTHER")
-        data_q1_v2 = {"patient": patient3.registration_number,
-                      "queue": self.queue1.pk}
+        patient3 = Patient.objects.create(name="Patient Three QOne", gender="OTHER")
+        data_q1_v2 = {"patient": patient3.registration_number, "queue": self.queue1.pk}
         response_q1_v2 = self.client.post(url, data_q1_v2, format="json")
         assert response_q1_v2.status_code == status.HTTP_201_CREATED
         # Incremented for Queue 1
@@ -379,8 +356,7 @@ class VisitAPITests(APITestCase):
         url = reverse("visit-list")
         # Missing patient
         data_no_patient = {"queue": self.queue1.pk}
-        response_no_patient = self.client.post(
-            url, data_no_patient, format="json")
+        response_no_patient = self.client.post(url, data_no_patient, format="json")
         assert response_no_patient.status_code == status.HTTP_400_BAD_REQUEST
         assert "patient" in response_no_patient.data
 
@@ -410,16 +386,14 @@ class VisitAPITests(APITestCase):
             status="WAITING",
         )
 
-        url_q1 = reverse("visit-list") + \
-            f"?status=WAITING&queue={self.queue1.pk}"
+        url_q1 = reverse("visit-list") + f"?status=WAITING&queue={self.queue1.pk}"
         response_q1 = self.client.get(url_q1, format="json")
         assert response_q1.status_code == status.HTTP_200_OK
         assert response_q1.data["count"] == 1
         assert response_q1.data["results"][0]["patient_full_name"] == self.patient.name
         assert response_q1.data["results"][0]["queue_name"] == self.queue1.name
 
-        url_q2 = reverse("visit-list") + \
-            f"?status=WAITING&queue={self.queue2.pk}"
+        url_q2 = reverse("visit-list") + f"?status=WAITING&queue={self.queue2.pk}"
         response_q2 = self.client.get(url_q2, format="json")
         assert response_q2.status_code == status.HTTP_200_OK
         assert response_q2.data["count"] == 1
@@ -470,8 +444,7 @@ class VisitAPITests(APITestCase):
             assert resp_d2_q1.data["visit_date"] == "2023-01-02"
 
             # Token for Queue 2 should also be 1 on this new day
-            patient2 = Patient.objects.create(
-                name="Day2 Q2 Patient", gender="FEMALE")
+            patient2 = Patient.objects.create(name="Day2 Q2 Patient", gender="FEMALE")
             data_d2_q2 = {
                 "patient": patient2.registration_number,
                 "queue": self.queue2.pk,
@@ -555,17 +528,18 @@ class VisitLifecycleTests(APITestCase):
         self.display_group, _ = Group.objects.get_or_create(name="Display")
 
         self.doctor_user = User.objects.create_user(
-            username="doctor", password="password")
+            username="doctor", password="password"
+        )
         self.doctor_user.groups.add(self.doctor_group)
         self.doctor_token = Token.objects.create(user=self.doctor_user)
 
         self.assistant_user = User.objects.create_user(
-            username="assistant", password="password")
+            username="assistant", password="password"
+        )
         self.assistant_user.groups.add(self.assistant_group)
         self.assistant_token = Token.objects.create(user=self.assistant_user)
 
-        self.patient = Patient.objects.create(
-            name="Test Patient", gender="OTHER")
+        self.patient = Patient.objects.create(name="Test Patient", gender="OTHER")
         self.queue = Queue.objects.create(name="Test Queue")
         self.visit = Visit.objects.create(
             patient=self.patient,
@@ -578,8 +552,7 @@ class VisitLifecycleTests(APITestCase):
         return reverse(f"visit-{action}", kwargs={"pk": pk})
 
     def test_doctor_can_transition_waiting_to_start(self):
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
         url = self._get_url("start", self.visit.pk)
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -589,8 +562,7 @@ class VisitLifecycleTests(APITestCase):
     def test_doctor_can_transition_start_to_in_room(self):
         self.visit.status = "START"
         self.visit.save()
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
 
         url = self._get_url("in-room", self.visit.pk)
         response = self.client.patch(url)
@@ -601,8 +573,7 @@ class VisitLifecycleTests(APITestCase):
     def test_doctor_can_transition_in_room_to_done(self):
         self.visit.status = "IN_ROOM"
         self.visit.save()
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
         url = self._get_url("done", self.visit.pk)
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -612,8 +583,7 @@ class VisitLifecycleTests(APITestCase):
     def test_doctor_can_send_back_to_waiting_from_start(self):
         self.visit.status = "START"
         self.visit.save()
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
         url = self._get_url("send-back-to-waiting", self.visit.pk)
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -621,8 +591,7 @@ class VisitLifecycleTests(APITestCase):
         self.assertEqual(self.visit.status, "WAITING")
 
     def test_invalid_transition_waiting_to_in_room(self):
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
         url = self._get_url("in-room", self.visit.pk)
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -630,8 +599,7 @@ class VisitLifecycleTests(APITestCase):
         self.assertEqual(self.visit.status, "WAITING")
 
     def test_invalid_transition_waiting_to_done(self):
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
         url = self._get_url("done", self.visit.pk)
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -639,8 +607,7 @@ class VisitLifecycleTests(APITestCase):
         self.assertEqual(self.visit.status, "WAITING")
 
     def test_assistant_cannot_change_status(self):
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.assistant_token.key}")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.assistant_token.key}")
         url = self._get_url("start", self.visit.pk)
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -648,8 +615,7 @@ class VisitLifecycleTests(APITestCase):
     def test_doctor_can_send_back_to_waiting_from_in_room(self):
         self.visit.status = "IN_ROOM"
         self.visit.save()
-        self.client.credentials(
-            HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
         url = self._get_url("send-back-to-waiting", self.visit.pk)
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/clinicq_backend/api/test_migrations.py
+++ b/clinicq_backend/api/test_migrations.py
@@ -91,8 +91,7 @@ def test_0003_backfill_creates_default_queue(migrator):
     # This means state '0002_...'
     # Apply all migrations up to the one just before the one we are testing.
     # This sets the DB schema to the state of migration 0002_...
-    migrator.apply_initial_migration(
-        ("api", "0003_backfill_visits_to_patients_queues"))
+    migrator.apply_initial_migration(("api", "0003_backfill_visits_to_patients_queues"))
 
     # Verify that 'General' queue does not exist at this point using the historical model from old_state
     # This ensures the test environment is clean if other tests/migrations might have created it.
@@ -105,8 +104,7 @@ def test_0003_backfill_creates_default_queue(migrator):
     # isolation.
 
     # Apply the data migration 0003 itself
-    migrator.apply_tested_migration(
-        ("api", "0003_backfill_visits_to_patients_queues"))
+    migrator.apply_tested_migration(("api", "0003_backfill_visits_to_patients_queues"))
 
     # After the migration, the database schema is now at state 0003.
     # Query using the live, current runtime models.
@@ -148,8 +146,7 @@ def test_0003_backfill_migrates_existing_visits(migrator):
         legacy_visit_count,
     )
 
-    migrator.apply_tested_migration(
-        ("api", "0003_backfill_visits_to_patients_queues"))
+    migrator.apply_tested_migration(("api", "0003_backfill_visits_to_patients_queues"))
 
     # After migration, query using live runtime models
     # from api.models import Queue as RuntimeQueue # Already imported
@@ -204,8 +201,7 @@ def test_0003_backfill_handles_no_existing_visits(migrator):
     assert OldVisitHistorical.objects.count() == 0
 
     # Apply migration 0003
-    migrator.apply_tested_migration(
-        ("api", "0003_backfill_visits_to_patients_queues"))
+    migrator.apply_tested_migration(("api", "0003_backfill_visits_to_patients_queues"))
 
     # After migration, query using live runtime models
     from api.models import Queue as RuntimeQueue
@@ -236,8 +232,7 @@ def test_0002_schema_migration_creates_indexes_and_unique_constraint(migrator):
     from django.db import connection, models
 
     with connection.cursor() as cursor:
-        cursor.execute(
-            f"PRAGMA index_list('{PatientAtState0002._meta.db_table}')")
+        cursor.execute(f"PRAGMA index_list('{PatientAtState0002._meta.db_table}')")
         indexes_on_table = [row[1] for row in cursor.fetchall()]
         assert "api_patient_phone_9d1c6b_idx" in indexes_on_table
         assert "api_patient_name_8aa05a_idx" in indexes_on_table
@@ -245,14 +240,12 @@ def test_0002_schema_migration_creates_indexes_and_unique_constraint(migrator):
     VisitMeta = VisitAtState0002._meta
     found_constraints = False
     if hasattr(VisitMeta, "unique_together") and VisitMeta.unique_together:
-        assert VisitMeta.unique_together == {
-            ("token_number", "visit_date", "queue")}
+        assert VisitMeta.unique_together == {("token_number", "visit_date", "queue")}
         found_constraints = True
     elif hasattr(VisitMeta, "constraints"):
         for constraint in VisitMeta.constraints:
             if isinstance(constraint, models.UniqueConstraint):
-                if set(constraint.fields) == {
-                        "token_number", "visit_date", "queue"}:
+                if set(constraint.fields) == {"token_number", "visit_date", "queue"}:
                     found_constraints = True
                     break
 

--- a/clinicq_backend/api/test_models.py
+++ b/clinicq_backend/api/test_models.py
@@ -16,8 +16,7 @@ class TestPatientModel:
         assert str(patient) == f"John Doe (ID: {patient.registration_number})"
 
     def test_patient_creation_defaults(self):
-        patient = Patient.objects.create(
-            name="Jane Smith")  # Gender defaults to OTHER
+        patient = Patient.objects.create(name="Jane Smith")  # Gender defaults to OTHER
         assert patient.gender == "OTHER"
         assert patient.phone is None  # Optional field
 
@@ -46,8 +45,7 @@ class TestVisitModel:
     def test_visit_creation_defaults_and_relations(self):
         # setUp is not automatically called by pytest for methods in a class unless it's a TestCase subclass
         # or specific pytest fixtures are used. For simplicity, creating here.
-        patient = Patient.objects.create(
-            name="Default Patient", gender="FEMALE")
+        patient = Patient.objects.create(name="Default Patient", gender="FEMALE")
         queue = Queue.objects.create(name="Default Queue")
 
         visit = Visit.objects.create(

--- a/clinicq_backend/api/views.py
+++ b/clinicq_backend/api/views.py
@@ -82,15 +82,14 @@ class PatientViewSet(viewsets.ModelViewSet):
             if len(raw_numbers) > 50:
                 raise ValidationError(
                     {
-                        "registration_numbers":
-                        "A maximum of 50 registration numbers are allowed."
+                        "registration_numbers": "A maximum of 50 registration numbers are allowed."
                     }
                 )
 
             numbers = []
             for num in raw_numbers:
                 # Accept formatted registration numbers (xx-xx-xxx pattern)
-                if re.match(r'^\d{2}-\d{2}-\d{3}$', num):
+                if re.match(r"^\d{2}-\d{2}-\d{3}$", num):
                     numbers.append(num)
                 # Also accept old numeric format for backward compatibility
                 # during transition
@@ -98,8 +97,7 @@ class PatientViewSet(viewsets.ModelViewSet):
                     if len(num) > 10:
                         raise ValidationError(
                             {
-                                "registration_numbers":
-                                "Registration numbers may not exceed 10 digits.",
+                                "registration_numbers": "Registration numbers may not exceed 10 digits.",
                             }
                         )
                     numbers.append(num)
@@ -148,7 +146,7 @@ class PatientViewSet(viewsets.ModelViewSet):
         filters = Q(name__icontains=query) | Q(phone__icontains=query)
 
         # Check if query matches registration number format (xx-xx-xxx)
-        if re.match(r'^\d{2}-\d{2}-\d{3}$', query):
+        if re.match(r"^\d{2}-\d{2}-\d{3}$", query):
             filters |= Q(registration_number=query)
         # Also check for old numeric format for backward compatibility
         elif query.isdigit():
@@ -156,9 +154,7 @@ class PatientViewSet(viewsets.ModelViewSet):
             # find registration numbers that might match this pattern
             filters |= Q(registration_number=query)
 
-        patients = Patient.objects.filter(filters).order_by(
-            "registration_number"
-        )
+        patients = Patient.objects.filter(filters).order_by("registration_number")
 
         # Paginate results if pagination is configured globally,
         # otherwise return all
@@ -178,17 +174,13 @@ class VisitViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_permissions(self):
-        if self.action == 'create':
+        if self.action == "create":
             permission_classes = [IsAssistant]
-        elif self.action in [
-            'start', 'in_room', 'send_back_to_waiting', 'done'
-        ]:
+        elif self.action in ["start", "in_room", "send_back_to_waiting", "done"]:
             permission_classes = [IsDoctor]
         elif (
-            self.action == 'list'
-            and self.request.user.groups.filter(
-                name__iexact='display'
-            ).exists()
+            self.action == "list"
+            and self.request.user.groups.filter(name__iexact="display").exists()
         ):
             permission_classes = [IsDisplay]
         else:
@@ -210,7 +202,7 @@ class VisitViewSet(viewsets.ModelViewSet):
         queue_id_param = self.request.query_params.get("queue")
 
         if status_param:
-            statuses = [s.strip().upper() for s in status_param.split(',')]
+            statuses = [s.strip().upper() for s in status_param.split(",")]
             queryset = queryset.filter(status__in=statuses)
             if "WAITING" in statuses:
                 # For WAITING status, always filter by today's date
@@ -241,9 +233,7 @@ class VisitViewSet(viewsets.ModelViewSet):
 
         next_token_number = 1
         if last_visit_in_queue_today:
-            next_token_number = (
-                last_visit_in_queue_today.token_number + 1
-            )
+            next_token_number = last_visit_in_queue_today.token_number + 1
 
         serializer.save(
             token_number=next_token_number,
@@ -251,8 +241,7 @@ class VisitViewSet(viewsets.ModelViewSet):
             status="WAITING",
         )
 
-    def _update_status(self, request, pk, new_status,
-                       expected_current_statuses):
+    def _update_status(self, request, pk, new_status, expected_current_statuses):
         visit = self.get_object()
         if visit.status not in expected_current_statuses:
             return Response(
@@ -268,13 +257,9 @@ class VisitViewSet(viewsets.ModelViewSet):
         )
         if serializer.is_valid():
             serializer.save()
-            full_visit_serializer = VisitSerializer(
-                visit, context={"request": request}
-            )
+            full_visit_serializer = VisitSerializer(visit, context={"request": request})
             return Response(full_visit_serializer.data)
-        return Response(
-            serializer.errors, status=status.HTTP_400_BAD_REQUEST
-        )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @action(detail=True, methods=["patch"])
     def start(self, request, pk=None):
@@ -286,8 +271,7 @@ class VisitViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["patch"])
     def send_back_to_waiting(self, request, pk=None):
-        return self._update_status(
-            request, pk, "WAITING", ["START", "IN_ROOM"])
+        return self._update_status(request, pk, "WAITING", ["START", "IN_ROOM"])
 
     @action(detail=True, methods=["patch"])
     def done(self, request, pk=None):
@@ -295,9 +279,7 @@ class VisitViewSet(viewsets.ModelViewSet):
 
 
 class PrescriptionImageViewSet(viewsets.ModelViewSet):
-    queryset = PrescriptionImage.objects.all().order_by(
-        "-created_at"
-    )
+    queryset = PrescriptionImage.objects.all().order_by("-created_at")
     serializer_class = PrescriptionImageSerializer
     parser_classes = (MultiPartParser, FormParser)
     permission_classes = [permissions.IsAuthenticated]
@@ -316,8 +298,7 @@ class PrescriptionImageViewSet(viewsets.ModelViewSet):
         if visit_id:
             queryset = queryset.filter(visit_id=visit_id)
         if patient_reg:
-            queryset = queryset.filter(
-                visit__patient__registration_number=patient_reg)
+            queryset = queryset.filter(visit__patient__registration_number=patient_reg)
         return queryset
 
     def create(self, request, *args, **kwargs):

--- a/clinicq_backend/clinicq_backend/settings.py
+++ b/clinicq_backend/clinicq_backend/settings.py
@@ -25,8 +25,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv(
-    "SECRET_KEY",
-    "django-insecure-@$43#sqi9t4_2&u38$v@l+3p37m&sp04afnk$usaf6f0z+2-*a"
+    "SECRET_KEY", "django-insecure-@$43#sqi9t4_2&u38$v@l+3p37m&sp04afnk$usaf6f0z+2-*a"
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
@@ -34,9 +33,7 @@ DEBUG = os.getenv("DEBUG", "True").lower() in ("true", "1", "yes", "on")
 
 _raw_allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", "localhost")
 ALLOWED_HOSTS: list[str] = [
-    host.strip()
-    for host in _raw_allowed_hosts.split(",")
-    if host.strip()
+    host.strip() for host in _raw_allowed_hosts.split(",") if host.strip()
 ]
 
 
@@ -130,22 +127,13 @@ AUTH_PASSWORD_VALIDATORS = [
         ),
     },
     {
-        "NAME": (
-            "django.contrib.auth.password_validation."
-            "MinimumLengthValidator"
-        ),
+        "NAME": ("django.contrib.auth.password_validation." "MinimumLengthValidator"),
     },
     {
-        "NAME": (
-            "django.contrib.auth.password_validation."
-            "CommonPasswordValidator"
-        ),
+        "NAME": ("django.contrib.auth.password_validation." "CommonPasswordValidator"),
     },
     {
-        "NAME": (
-            "django.contrib.auth.password_validation."
-            "NumericPasswordValidator"
-        ),
+        "NAME": ("django.contrib.auth.password_validation." "NumericPasswordValidator"),
     },
 ]
 
@@ -223,13 +211,10 @@ REST_FRAMEWORK = {
 # CORS Configuration
 # Allow both development (frontend on different port) and production origins
 _cors_allowed_origins = os.getenv(
-    "CORS_ALLOWED_ORIGINS",
-    "http://localhost:5173,http://127.0.0.1:5173"
+    "CORS_ALLOWED_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173"
 )
 CORS_ALLOWED_ORIGINS = [
-    origin.strip()
-    for origin in _cors_allowed_origins.split(",")
-    if origin.strip()
+    origin.strip() for origin in _cors_allowed_origins.split(",") if origin.strip()
 ]
 
 # For development, allow credentials (cookies, authorization headers)
@@ -255,32 +240,39 @@ CORS_ALLOW_HEADERS = [
 _csrf_origins = os.getenv("CSRF_TRUSTED_ORIGINS", "")
 if _csrf_origins:
     CSRF_TRUSTED_ORIGINS = [
-        origin.strip()
-        for origin in _csrf_origins.split(",")
-        if origin.strip()
+        origin.strip() for origin in _csrf_origins.split(",") if origin.strip()
     ]
 
 # Security middleware settings (enabled in production)
-SECURE_SSL_REDIRECT = os.getenv(
-    "SECURE_SSL_REDIRECT", "false").lower() in (
-        "true", "1", "yes", "on")
+SECURE_SSL_REDIRECT = os.getenv("SECURE_SSL_REDIRECT", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+    "on",
+)
 SECURE_HSTS_SECONDS = int(os.getenv("SECURE_HSTS_SECONDS", "0"))
 SECURE_HSTS_INCLUDE_SUBDOMAINS = os.getenv(
-    "SECURE_HSTS_INCLUDE_SUBDOMAINS", "false").lower() in (
-        "true", "1", "yes", "on")
-SECURE_HSTS_PRELOAD = os.getenv(
-    "SECURE_HSTS_PRELOAD", "false").lower() in (
-        "true", "1", "yes", "on")
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS", "false"
+).lower() in ("true", "1", "yes", "on")
+SECURE_HSTS_PRELOAD = os.getenv("SECURE_HSTS_PRELOAD", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+    "on",
+)
 SECURE_CONTENT_TYPE_NOSNIFF = os.getenv(
-    "SECURE_CONTENT_TYPE_NOSNIFF", "true").lower() in (
-        "true", "1", "yes", "on")
-SECURE_BROWSER_XSS_FILTER = os.getenv(
-    "SECURE_BROWSER_XSS_FILTER", "true").lower() in (
-        "true", "1", "yes", "on")
+    "SECURE_CONTENT_TYPE_NOSNIFF", "true"
+).lower() in ("true", "1", "yes", "on")
+SECURE_BROWSER_XSS_FILTER = os.getenv("SECURE_BROWSER_XSS_FILTER", "true").lower() in (
+    "true",
+    "1",
+    "yes",
+    "on",
+)
 X_FRAME_OPTIONS = os.getenv("X_FRAME_OPTIONS", "SAMEORIGIN")
 SECURE_REFERRER_POLICY = os.getenv(
-    "SECURE_REFERRER_POLICY",
-    "strict-origin-when-cross-origin")
+    "SECURE_REFERRER_POLICY", "strict-origin-when-cross-origin"
+)
 
 # Session security
 SESSION_COOKIE_SECURE = SECURE_SSL_REDIRECT

--- a/clinicq_backend/tests/test_migration_fix.py
+++ b/clinicq_backend/tests/test_migration_fix.py
@@ -4,6 +4,7 @@ Test to verify the fix for migration 0008_alter_patient_registration_number.py
 This test verifies that using registration_number=patient.pk instead of
 pk=patient.pk works correctly in the migration functions.
 """
+
 from django.test import TestCase
 from api.models import Patient
 
@@ -15,9 +16,7 @@ class TestMigrationPKFix(TestCase):
         """Test that filtering by registration_number works with formatted numbers"""
         # Create a patient with formatted registration number
         patient = Patient.objects.create(
-            registration_number="01-23-456",
-            name="Test Patient",
-            gender="MALE"
+            registration_number="01-23-456", name="Test Patient", gender="MALE"
         )
 
         # Verify that filtering by registration_number=patient.pk works
@@ -27,9 +26,9 @@ class TestMigrationPKFix(TestCase):
         self.assertEqual(found_patients.first(), patient)
 
         # Verify that update operations work
-        updated_count = Patient.objects.filter(
-            registration_number=patient.pk
-        ).update(name="Updated Name")
+        updated_count = Patient.objects.filter(registration_number=patient.pk).update(
+            name="Updated Name"
+        )
         self.assertEqual(updated_count, 1)
 
         patient.refresh_from_db()
@@ -39,16 +38,13 @@ class TestMigrationPKFix(TestCase):
         """Test that filtering works with edge cases like leading zeros"""
         # Create patient with leading zeros
         patient = Patient.objects.create(
-            registration_number="00-00-001",
-            name="Edge Case Patient",
-            gender="FEMALE"
+            registration_number="00-00-001", name="Edge Case Patient", gender="FEMALE"
         )
 
         # Test filtering - this would be the same as the migration logic
         filter_result = Patient.objects.filter(registration_number=patient.pk)
         self.assertEqual(filter_result.count(), 1)
-        self.assertEqual(
-            filter_result.first().registration_number, "00-00-001")
+        self.assertEqual(filter_result.first().registration_number, "00-00-001")
 
     def test_migration_simulation_forward_conversion(self):
         """Simulate the forward migration conversion logic"""
@@ -57,7 +53,7 @@ class TestMigrationPKFix(TestCase):
         patient = Patient.objects.create(
             registration_number="1234567",  # Simulates integer stored as string
             name="Integer Format Patient",
-            gender="OTHER"
+            gender="OTHER",
         )
 
         # Simulate the forward conversion logic from the migration
@@ -65,9 +61,9 @@ class TestMigrationPKFix(TestCase):
         formatted = f"{number_str[:2]}-{number_str[2:4]}-{number_str[4:]}"
 
         # Test the filter that was fixed in the migration
-        updated_count = Patient.objects.filter(
-            registration_number=patient.pk
-        ).update(registration_number=formatted)
+        updated_count = Patient.objects.filter(registration_number=patient.pk).update(
+            registration_number=formatted
+        )
 
         self.assertEqual(updated_count, 1)
 
@@ -80,9 +76,7 @@ class TestMigrationPKFix(TestCase):
         """Simulate the reverse migration conversion logic"""
         # Create a patient with formatted registration number
         patient = Patient.objects.create(
-            registration_number="99-88-777",
-            name="Formatted Patient",
-            gender="MALE"
+            registration_number="99-88-777", name="Formatted Patient", gender="MALE"
         )
 
         # Simulate the reverse conversion logic from the migration
@@ -90,9 +84,9 @@ class TestMigrationPKFix(TestCase):
         integer_value = int(numeric_str)
 
         # Test the filter that was fixed in the migration
-        updated_count = Patient.objects.filter(
-            registration_number=patient.pk
-        ).update(registration_number=str(integer_value))
+        updated_count = Patient.objects.filter(registration_number=patient.pk).update(
+            registration_number=str(integer_value)
+        )
 
         self.assertEqual(updated_count, 1)
 


### PR DESCRIPTION
## Summary
- run Black across the API app, migrations, and tests to remove trailing whitespace and satisfy linting
- normalize formatting in Django settings to match Black's style guide

## Testing
- not run (formatting-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8f8e4f7648323b9ee6b613da1d123