### PR TITLE
Fix CORS comment formatting and clean Visit model

### DIFF
--- a/clinicq_backend/api/models.py
+++ b/clinicq_backend/api/models.py
@@ -56,7 +56,7 @@ class Visit(models.Model):
         ordering = ["visit_date", "queue", "token_number"]
 
     def __str__(self):
-copilot/fix-4f4f38f6-a06c-4659-a54b-f19c0e62ad75
+        # copilot/fix-4f4f38f6-a06c-4659-a54b-f19c0e62ad75
         return (
             f"Token {self.token_number} - {self.patient.name} " f"({self.visit_date})"
         )

--- a/clinicq_backend/clinicq_backend/settings.py
+++ b/clinicq_backend/clinicq_backend/settings.py
@@ -209,13 +209,13 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticated",
     ],
 }
-CORS Configuration
-Allow both development (frontend on different port) and production origins
+# CORS configuration
+# Allow both development (frontend on different port) and production origins
 _cors_allowed_origins = os.getenv(
     "CORS_ALLOWED_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173"
 )
 CORS_ALLOWED_ORIGINS = [
-    origin.strip() for origin in _cors_allowed_origins.split(",") if origin.strip(
+    origin.strip() for origin in _cors_allowed_origins.split(",") if origin.strip()
 ]
 # For quick local smoke tests only (remove in prod):
 # CORS_ALLOW_ALL_ORIGINS = True


### PR DESCRIPTION
## Summary
- convert stray prose in the settings CORS block into comments and fix the origin stripping comprehension
- comment the leftover copilot marker in the Visit model to restore valid syntax

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68d90a30b14c83238a81a444d4df234f