### PR TITLE
Remove stray copilot marker from tests

### DIFF
--- a/clinicq_backend/api/test_models.py
+++ b/clinicq_backend/api/test_models.py
@@ -156,7 +156,6 @@ class TestVisitModel:
         # This test might be redundant if the field is only for data migration.
 
     # Removed tests that directly tested VisitSerializer's old create()
-    copilot/fix-00a3112f-93d2-4af5-a587-73b7b86b29aa
     # behavior for token/date generation
     # as this logic is now in VisitViewSet.perform_create() and covered by API
     # tests.


### PR DESCRIPTION
## Summary
- remove the stray copilot/fix reference from the Visit serializer test comment while keeping the surrounding explanation intact

## Testing
- pytest clinicq_backend/api/test_models.py *(fails: missing dependency django_test_migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68d90a2e1578832381239cade9a6ada5