### PR TITLE
Add public display kiosk mode screen for queue

### DIFF
--- a/clinicq_Mobile/package.json
+++ b/clinicq_Mobile/package.json
@@ -31,6 +31,7 @@
     "expo-file-system": "~16.0.9",
     "expo-image-picker": "~15.0.7",
     "expo-localization": "~15.4.2",
+    "expo-keep-awake": "~12.0.0",
     "expo-secure-store": "~13.0.2",
     "expo-status-bar": "~1.11.1",
     "i18next": "^23.8.2",

--- a/clinicq_Mobile/src/api/hooks/usePublicDisplayQueue.ts
+++ b/clinicq_Mobile/src/api/hooks/usePublicDisplayQueue.ts
@@ -1,0 +1,64 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/api/client';
+import { queryKeys } from '@/constants/queryKeys';
+import type { Patient, Visit } from '@/api/generated/types';
+
+export interface PublicDisplayEntry {
+  visit: Visit;
+  patient?: Patient;
+  position: number;
+}
+
+const fetchPublicDisplayQueue = async (): Promise<PublicDisplayEntry[]> => {
+  const [inProgressResponse, waitingResponse] = await Promise.all([
+    apiClient.listVisits({ status: 'in_progress' }),
+    apiClient.listVisits({ status: 'waiting' })
+  ]);
+
+  const inProgressVisits = [...inProgressResponse.data.results].sort(
+    (a, b) => new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime()
+  );
+  const waitingVisits = [...waitingResponse.data.results].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
+
+  const visits = [...inProgressVisits, ...waitingVisits].slice(0, 20);
+
+  if (visits.length === 0) {
+    return [];
+  }
+
+  const uniquePatientIds = Array.from(new Set(visits.map((visit) => visit.patient)));
+
+  const patients = await Promise.all(
+    uniquePatientIds.map(async (id) => {
+      try {
+        const response = await apiClient.getPatient(id);
+        return response.data;
+      } catch (error) {
+        return null;
+      }
+    })
+  );
+
+  const patientMap = new Map<number, Patient>();
+  patients.forEach((patient) => {
+    if (patient) {
+      patientMap.set(patient.id, patient);
+    }
+  });
+
+  return visits.map((visit, index) => ({
+    visit,
+    patient: patientMap.get(visit.patient),
+    position: index + 1
+  }));
+};
+
+export const usePublicDisplayQueue = () =>
+  useQuery({
+    queryKey: queryKeys.publicDisplayQueue(),
+    queryFn: fetchPublicDisplayQueue,
+    refetchInterval: 10000,
+    refetchIntervalInBackground: true
+  });

--- a/clinicq_Mobile/src/constants/queryKeys.ts
+++ b/clinicq_Mobile/src/constants/queryKeys.ts
@@ -7,5 +7,6 @@ export const queryKeys = {
   visit: (id: number | string) => ['visit', id] as const,
   uploads: ['uploads'] as const,
   health: ['diagnostics', 'health'] as const,
-  version: ['diagnostics', 'version'] as const
+  version: ['diagnostics', 'version'] as const,
+  publicDisplayQueue: () => ['public-display', 'queue'] as const
 };

--- a/clinicq_Mobile/src/navigation/index.tsx
+++ b/clinicq_Mobile/src/navigation/index.tsx
@@ -11,6 +11,7 @@ import { VisitsQueueScreen } from '@/screens/VisitsQueueScreen';
 import { DoctorQueueScreen } from '@/screens/DoctorQueueScreen';
 import { UploadManagerScreen } from '@/screens/UploadManagerScreen';
 import { DiagnosticsScreen } from '@/screens/DiagnosticsScreen';
+import { PublicDisplayScreen } from '@/screens/PublicDisplayScreen';
 import { LoadingIndicator } from '@/components/LoadingIndicator';
 import { ROLES } from '@/constants';
 import type { AppStackParamList, AssistantTabParamList, AuthStackParamList, DoctorTabParamList } from './types';
@@ -43,6 +44,11 @@ const AssistantStack = () => (
     <App.Screen name="PatientDetail" component={PatientDetailScreen} options={{ title: 'Patient detail' }} />
     <App.Screen name="PatientForm" component={PatientFormScreen} options={{ title: 'Patient form' }} />
     <App.Screen name="VisitDetail" component={VisitDetailScreen} options={{ title: 'Visit detail' }} />
+    <App.Screen
+      name="PublicDisplay"
+      component={PublicDisplayScreen}
+      options={{ headerShown: false, presentation: 'fullScreenModal', gestureEnabled: false }}
+    />
   </App.Navigator>
 );
 
@@ -52,6 +58,11 @@ const DoctorStack = () => (
     <App.Screen name="PatientDetail" component={PatientDetailScreen} options={{ title: 'Patient detail' }} />
     <App.Screen name="PatientForm" component={PatientFormScreen} options={{ title: 'Patient form' }} />
     <App.Screen name="VisitDetail" component={VisitDetailScreen} options={{ title: 'Visit detail' }} />
+    <App.Screen
+      name="PublicDisplay"
+      component={PublicDisplayScreen}
+      options={{ headerShown: false, presentation: 'fullScreenModal', gestureEnabled: false }}
+    />
   </App.Navigator>
 );
 

--- a/clinicq_Mobile/src/navigation/types.ts
+++ b/clinicq_Mobile/src/navigation/types.ts
@@ -3,6 +3,7 @@ export type AppStackParamList = {
   PatientDetail: { patientId: number };
   PatientForm: { patientId?: number };
   VisitDetail: { visitId: number };
+  PublicDisplay: undefined;
 };
 
 export type AssistantTabParamList = {

--- a/clinicq_Mobile/src/screens/DiagnosticsScreen.tsx
+++ b/clinicq_Mobile/src/screens/DiagnosticsScreen.tsx
@@ -5,11 +5,15 @@ import { useHealth, useVersion } from '@/api/hooks/useDiagnostics';
 import { LoadingIndicator } from '@/components/LoadingIndicator';
 import { ErrorState } from '@/components/ErrorState';
 import { useAuth } from '@/features/auth/AuthContext';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { AppStackParamList } from '@/navigation/types';
 
 export const DiagnosticsScreen: React.FC = () => {
   const health = useHealth();
   const version = useVersion();
   const { refreshProfile, logout } = useAuth();
+  const navigation = useNavigation<NativeStackNavigationProp<AppStackParamList>>();
 
   if (health.isLoading || version.isLoading) {
     return <LoadingIndicator />;
@@ -37,6 +41,13 @@ export const DiagnosticsScreen: React.FC = () => {
 
       <Button mode="outlined" onPress={() => { health.refetch(); version.refetch(); }} style={{ marginBottom: 12 }}>
         Refresh diagnostics
+      </Button>
+      <Button
+        mode="outlined"
+        onPress={() => navigation.navigate('PublicDisplay')}
+        style={{ marginBottom: 12 }}
+      >
+        Open public display
       </Button>
       <Button mode="outlined" onPress={() => refreshProfile()} style={{ marginBottom: 12 }}>
         Refresh profile

--- a/clinicq_Mobile/src/screens/PublicDisplayScreen.tsx
+++ b/clinicq_Mobile/src/screens/PublicDisplayScreen.tsx
@@ -1,0 +1,260 @@
+import React from 'react';
+import { FlatList, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { Button } from 'react-native-paper';
+import { useKeepAwake } from 'expo-keep-awake';
+import { setStatusBarHidden } from 'expo-status-bar';
+import NetInfo from '@react-native-community/netinfo';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { AppStackParamList } from '@/navigation/types';
+import { usePublicDisplayQueue } from '@/api/hooks/usePublicDisplayQueue';
+import type { PublicDisplayEntry } from '@/api/hooks/usePublicDisplayQueue';
+
+const formatName = (entry: PublicDisplayEntry) => {
+  const patient = entry.patient;
+  if (patient) {
+    return `${patient.first_name} ${patient.last_name}`.trim();
+  }
+  return `Patient #${entry.visit.patient}`;
+};
+
+const formatStatus = (status: string) =>
+  status
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+export const PublicDisplayScreen: React.FC = () => {
+  useKeepAwake();
+  const navigation = useNavigation<NativeStackNavigationProp<AppStackParamList>>();
+  const queueQuery = usePublicDisplayQueue();
+  const [isOffline, setIsOffline] = React.useState(false);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      setStatusBarHidden(true, 'fade');
+      const unsubscribeNetInfo = NetInfo.addEventListener((state) => {
+        setIsOffline(!(state.isConnected && state.isInternetReachable !== false));
+      });
+
+      NetInfo.fetch().then((state) => {
+        setIsOffline(!(state.isConnected && state.isInternetReachable !== false));
+      });
+
+      return () => {
+        setStatusBarHidden(false, 'fade');
+        unsubscribeNetInfo();
+      };
+    }, [])
+  );
+
+  const entries = queueQuery.data ?? [];
+  const nowServing = entries.find((entry) => entry.visit.status === 'in_progress') ?? entries[0];
+  const waiting = nowServing
+    ? entries.filter((entry) => entry.visit.id !== nowServing.visit.id)
+    : entries;
+
+  const lastUpdated = queueQuery.dataUpdatedAt ? new Date(queueQuery.dataUpdatedAt).toLocaleTimeString() : null;
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Clinic Queue</Text>
+          <View style={styles.headerRight}>
+            {isOffline ? <Text style={styles.offline}>Offline mode</Text> : null}
+            <Text style={styles.timestamp}>{lastUpdated ? `Updated ${lastUpdated}` : 'Fetching…'}</Text>
+          </View>
+        </View>
+
+        {queueQuery.isLoading ? (
+          <View style={styles.centerContent}>
+            <Text style={styles.loadingText}>Loading queue…</Text>
+          </View>
+        ) : queueQuery.isError ? (
+          <View style={styles.centerContent}>
+            <Text style={styles.errorText}>Unable to load queue data</Text>
+            <Button mode="outlined" onPress={() => queueQuery.refetch()} style={styles.retryButton}>
+              Try again
+            </Button>
+          </View>
+        ) : entries.length === 0 ? (
+          <View style={styles.centerContent}>
+            <Text style={styles.emptyText}>No patients are currently waiting</Text>
+          </View>
+        ) : (
+          <>
+            {nowServing ? (
+              <View style={styles.nowServingCard}>
+                <Text style={styles.nowServingLabel}>Now serving</Text>
+                <Text style={styles.nowServingName}>{formatName(nowServing)}</Text>
+                <Text style={styles.nowServingMeta}>Visit #{nowServing.visit.id}</Text>
+              </View>
+            ) : null}
+
+            <View style={styles.waitingHeader}>
+              <Text style={styles.waitingTitle}>Up next</Text>
+              <Button mode="text" onPress={() => queueQuery.refetch()} loading={queueQuery.isFetching}>
+                Refresh
+              </Button>
+            </View>
+            <FlatList
+              data={waiting}
+              keyExtractor={(item) => String(item.visit.id)}
+              contentContainerStyle={waiting.length === 0 ? styles.emptyList : undefined}
+              renderItem={({ item, index }) => (
+                <View style={styles.waitingRow}>
+                  <Text style={styles.waitingPosition}>{index + 1}</Text>
+                  <View style={styles.waitingInfo}>
+                    <Text style={styles.waitingName}>{formatName(item)}</Text>
+                    <Text style={styles.waitingMeta}>
+                      Visit #{item.visit.id} · {formatStatus(item.visit.status)}
+                    </Text>
+                  </View>
+                </View>
+              )}
+              ListEmptyComponent={() => (
+                <Text style={styles.emptyText}>Everyone has been seen. 🎉</Text>
+              )}
+            />
+          </>
+        )}
+
+        <View style={styles.footer}>
+          <Button mode="contained" onPress={() => navigation.goBack()} style={styles.exitButton}>
+            Exit kiosk mode
+          </Button>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#0f172a'
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingVertical: 16,
+    gap: 24
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  headerRight: {
+    alignItems: 'flex-end'
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '700',
+    color: '#f8fafc'
+  },
+  offline: {
+    color: '#f97316',
+    fontSize: 16,
+    fontWeight: '600'
+  },
+  timestamp: {
+    color: '#cbd5f5',
+    fontSize: 14
+  },
+  centerContent: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  loadingText: {
+    fontSize: 24,
+    color: '#e2e8f0'
+  },
+  errorText: {
+    fontSize: 22,
+    color: '#fecdd3',
+    textAlign: 'center'
+  },
+  retryButton: {
+    marginTop: 16
+  },
+  emptyText: {
+    fontSize: 22,
+    color: '#94a3b8',
+    textAlign: 'center'
+  },
+  nowServingCard: {
+    backgroundColor: '#1e293b',
+    borderRadius: 16,
+    padding: 24,
+    alignItems: 'center',
+    gap: 8
+  },
+  nowServingLabel: {
+    fontSize: 20,
+    color: '#38bdf8',
+    textTransform: 'uppercase',
+    letterSpacing: 2
+  },
+  nowServingName: {
+    fontSize: 48,
+    fontWeight: '700',
+    color: '#f8fafc',
+    textAlign: 'center'
+  },
+  nowServingMeta: {
+    fontSize: 20,
+    color: '#cbd5f5'
+  },
+  waitingHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  waitingTitle: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#e2e8f0'
+  },
+  waitingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#1e293b',
+    borderRadius: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 20,
+    marginBottom: 12
+  },
+  waitingPosition: {
+    fontSize: 32,
+    fontWeight: '700',
+    color: '#38bdf8',
+    width: 48
+  },
+  waitingInfo: {
+    flex: 1
+  },
+  waitingName: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#f1f5f9'
+  },
+  waitingMeta: {
+    fontSize: 16,
+    color: '#cbd5f5',
+    marginTop: 4
+  },
+  emptyList: {
+    flexGrow: 1,
+    justifyContent: 'center'
+  },
+  footer: {
+    paddingBottom: 12
+  },
+  exitButton: {
+    alignSelf: 'center',
+    minWidth: 240
+  }
+});


### PR DESCRIPTION
## Summary
- add Expo keep awake dependency and a dedicated query key for the public display queue
- implement a usePublicDisplayQueue hook and kiosk-friendly PublicDisplayScreen with offline awareness
- expose the public display launcher in diagnostics and navigation so staff can open the queue display

## Testing
- npm install --no-progress *(fails: expo-localization@~15.4.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df09328ebc832382025014e3269183