### PR TITLE
Add sync status banner for offline queue visibility

### DIFF
--- a/apps/mobile/docs/STATUS.md
+++ b/apps/mobile/docs/STATUS.md
@@ -132,6 +132,10 @@ The application has completed all Phase 1 & 2 foundational work and core workflo
   - Automatic replay when connection restored
   - Request serialization including FormData
   - Persistent storage using secure store
+- **Sync Status Banner** (`src/components/SyncStatusBanner.tsx`)
+  - Surfaces offline mode with cached data context
+  - Shows queued mutation count and last sync/queue timestamps
+  - Uses portal overlay so status is visible on every screen
   
 - **Outbox Processor** (`src/api/outbox/useOutboxProcessor.ts`)
   - Background processing hook

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'jest-expo',
   setupFilesAfterEnv: ['./jest.setup.ts'],
   transformIgnorePatterns: [
-    'node_modules/(?!(jest-)?react-native|@react-native|@react-navigation|expo-|@expo|@unimodules|unimodules|sentry-expo|native-base)'
+    'node_modules/(?!(jest-)?react-native|@react-native|@react-navigation|expo($|/)|expo-|@expo|@unimodules|unimodules|sentry-expo|native-base)'
   ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'

--- a/apps/mobile/src/api/outbox/outbox.test.ts
+++ b/apps/mobile/src/api/outbox/outbox.test.ts
@@ -1,0 +1,41 @@
+import { outbox } from './outbox';
+import type { OutboxEntry } from './types';
+
+jest.mock('@/storage/secureStore', () => {
+  const store = new Map<string, string>();
+  return {
+    secureStore: {
+      getString: jest.fn(async (key: string) => store.get(key) ?? null),
+      setString: jest.fn(async (key: string, value: string) => {
+        store.set(key, value);
+      }),
+      remove: jest.fn(async (key: string) => {
+        store.delete(key);
+      })
+    }
+  };
+});
+
+describe('outbox subscribe', () => {
+  afterEach(async () => {
+    const entries = await outbox.list();
+    await Promise.all(entries.map((entry) => outbox.remove(entry.id)));
+  });
+
+  it('notifies listeners when entries change', async () => {
+    const events: OutboxEntry[][] = [];
+    const unsubscribe = outbox.subscribe((entries) => {
+      events.push(entries);
+    });
+
+    const created = await outbox.enqueue('post', '/patients', { name: 'Alice' });
+
+    expect(events.at(-1)).toEqual([created]);
+
+    await outbox.remove(created.id);
+
+    expect(events.at(-1)).toEqual([]);
+
+    unsubscribe();
+  });
+});

--- a/apps/mobile/src/api/outbox/useOutboxStatus.ts
+++ b/apps/mobile/src/api/outbox/useOutboxStatus.ts
@@ -1,0 +1,67 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { outbox } from './outbox';
+import type { OutboxEntry } from './types';
+
+interface OutboxStatus {
+  entries: OutboxEntry[];
+  pendingCount: number;
+  hasPending: boolean;
+  lastQueuedAt?: string;
+  lastSyncedAt?: string;
+}
+
+export const useOutboxStatus = (): OutboxStatus => {
+  const [entries, setEntries] = useState<OutboxEntry[]>([]);
+  const [lastSyncedAt, setLastSyncedAt] = useState<string | undefined>();
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    const load = async () => {
+      const initialEntries = await outbox.list();
+      if (mountedRef.current) {
+        setEntries(initialEntries);
+        if (initialEntries.length === 0) {
+          setLastSyncedAt(new Date().toISOString());
+        }
+      }
+    };
+
+    load();
+
+    const unsubscribe = outbox.subscribe((nextEntries) => {
+      if (!mountedRef.current) return;
+      setEntries(nextEntries);
+      if (nextEntries.length === 0) {
+        setLastSyncedAt(new Date().toISOString());
+      }
+    });
+
+    return () => {
+      mountedRef.current = false;
+      unsubscribe();
+    };
+  }, []);
+
+  const lastQueuedAt = useMemo(() => {
+    if (entries.length === 0) {
+      return undefined;
+    }
+
+    return entries.reduce((latest, entry) => {
+      if (!latest) {
+        return entry.createdAt;
+      }
+      return new Date(entry.createdAt).getTime() > new Date(latest).getTime() ? entry.createdAt : latest;
+    }, undefined as string | undefined);
+  }, [entries]);
+
+  return {
+    entries,
+    pendingCount: entries.length,
+    hasPending: entries.length > 0,
+    lastQueuedAt,
+    lastSyncedAt
+  };
+};

--- a/apps/mobile/src/components/SyncStatusBanner.tsx
+++ b/apps/mobile/src/components/SyncStatusBanner.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Banner, Portal, Text, useTheme } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { formatDistanceToNow } from 'date-fns';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+import { useOutboxStatus } from '@/api/outbox/useOutboxStatus';
+
+const formatRelativeTime = (isoDate?: string) => {
+  if (!isoDate) {
+    return undefined;
+  }
+
+  try {
+    return formatDistanceToNow(new Date(isoDate), { addSuffix: true });
+  } catch (error) {
+    return undefined;
+  }
+};
+
+export const SyncStatusBanner: React.FC = () => {
+  const { isOffline } = useNetworkStatus();
+  const { pendingCount, lastQueuedAt, lastSyncedAt } = useOutboxStatus();
+  const show = isOffline || pendingCount > 0;
+  const [visible, setVisible] = React.useState(show);
+  const insets = useSafeAreaInsets();
+  const theme = useTheme();
+
+  React.useEffect(() => {
+    setVisible(show);
+  }, [show]);
+
+  if (!show) {
+    return null;
+  }
+
+  const queuedDescriptor = pendingCount > 0 ? `${pendingCount} update${pendingCount === 1 ? '' : 's'} queued` : undefined;
+  const statusDescriptor = isOffline ? 'Offline mode · showing cached data' : 'Back online';
+  const lastQueuedRelative = formatRelativeTime(lastQueuedAt);
+  const lastSyncedRelative = !isOffline && pendingCount === 0 ? formatRelativeTime(lastSyncedAt) : undefined;
+
+  const message = [statusDescriptor, queuedDescriptor].filter(Boolean).join(' · ');
+
+  const supportingText = lastQueuedRelative
+    ? `Last update queued ${lastQueuedRelative}`
+    : lastSyncedRelative
+      ? `Last sync ${lastSyncedRelative}`
+      : undefined;
+
+  const backgroundColor = isOffline
+    ? theme.colors.errorContainer || '#FFE5E7'
+    : theme.colors.primaryContainer || '#E3F2FD';
+
+  const textColor = isOffline
+    ? theme.colors.onErrorContainer || theme.colors.error
+    : theme.colors.onPrimaryContainer || theme.colors.primary;
+
+  const icon = isOffline ? 'cloud-off-outline' : pendingCount > 0 ? 'cloud-upload-outline' : 'cloud-check-outline';
+
+  return (
+    <Portal>
+      <View pointerEvents="box-none" style={[styles.wrapper, { paddingTop: insets.top + 8 }]}> 
+        <Banner visible={visible} style={[styles.banner, { backgroundColor }]} icon={icon}>
+          <View style={styles.content}> 
+            <Text variant="titleSmall" style={[styles.message, { color: textColor }]}>
+              {message}
+            </Text>
+            {supportingText ? (
+              <Text variant="bodySmall" style={[styles.supporting, { color: textColor }]}> 
+                {supportingText}
+              </Text>
+            ) : null}
+          </View>
+        </Banner>
+      </View>
+    </Portal>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10
+  },
+  banner: {
+    marginHorizontal: 16,
+    borderRadius: 12,
+    overflow: 'hidden',
+    elevation: 2
+  },
+  content: {
+    gap: 4
+  },
+  message: {
+    fontWeight: '600'
+  },
+  supporting: {
+    opacity: 0.85
+  }
+});

--- a/apps/mobile/src/components/__tests__/SyncStatusBanner.test.tsx
+++ b/apps/mobile/src/components/__tests__/SyncStatusBanner.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SyncStatusBanner } from '@/components/SyncStatusBanner';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
+import { useOutboxStatus } from '@/api/outbox/useOutboxStatus';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })
+}));
+
+jest.mock('react-native-paper', () => {
+  const React = require('react');
+  const { Text: RNText } = require('react-native');
+  return {
+    Banner: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Text: ({ children, ...props }: { children: React.ReactNode }) => <RNText {...props}>{children}</RNText>,
+    useTheme: () => ({
+      colors: {
+        errorContainer: '#fee',
+        onErrorContainer: '#900',
+        primaryContainer: '#eef',
+        onPrimaryContainer: '#006'
+      }
+    }),
+    Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>
+  };
+});
+
+jest.mock('@/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: jest.fn()
+}));
+
+jest.mock('@/api/outbox/useOutboxStatus', () => ({
+  useOutboxStatus: jest.fn()
+}));
+
+const mockedUseNetworkStatus = useNetworkStatus as jest.MockedFunction<typeof useNetworkStatus>;
+const mockedUseOutboxStatus = useOutboxStatus as jest.MockedFunction<typeof useOutboxStatus>;
+
+describe('SyncStatusBanner', () => {
+  const renderBanner = () => render(<SyncStatusBanner />);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseNetworkStatus.mockReturnValue({ isOffline: false });
+    mockedUseOutboxStatus.mockReturnValue({ pendingCount: 0, lastQueuedAt: undefined, lastSyncedAt: undefined });
+  });
+
+  it('shows offline cached message when offline with queue', async () => {
+    mockedUseNetworkStatus.mockReturnValue({ isOffline: true });
+    mockedUseOutboxStatus.mockReturnValue({
+      pendingCount: 2,
+      lastQueuedAt: new Date('2024-01-01T10:00:00Z').toISOString(),
+      lastSyncedAt: undefined
+    });
+
+    const { getByText } = renderBanner();
+
+    expect(mockedUseNetworkStatus).toHaveBeenCalled();
+    expect(mockedUseOutboxStatus).toHaveBeenCalled();
+    expect(getByText(/Offline mode/i)).toBeTruthy();
+    expect(getByText(/2 updates queued/i)).toBeTruthy();
+  });
+
+  it('shows sync message when back online', async () => {
+    mockedUseNetworkStatus.mockReturnValue({ isOffline: false });
+    mockedUseOutboxStatus.mockReturnValue({
+      pendingCount: 1,
+      lastQueuedAt: new Date('2024-01-01T12:00:00Z').toISOString(),
+      lastSyncedAt: undefined
+    });
+
+    const { getByText } = renderBanner();
+
+    expect(getByText(/Back online/)).toBeTruthy();
+    expect(getByText(/Last update queued/i)).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/hooks/useNetworkStatus.ts
+++ b/apps/mobile/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import NetInfo, { NetInfoState } from '@react-native-community/netinfo';
+
+interface NetworkStatus {
+  isOffline: boolean;
+  netInfo?: NetInfoState;
+}
+
+const isOffline = (state: NetInfoState | null) => {
+  if (!state) {
+    return false;
+  }
+
+  if (state.isConnected === false) {
+    return true;
+  }
+
+  if (state.isInternetReachable === false) {
+    return true;
+  }
+
+  return false;
+};
+
+export const useNetworkStatus = (): NetworkStatus => {
+  const [netInfo, setNetInfo] = useState<NetInfoState | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    NetInfo.fetch().then((state) => {
+      if (isMounted) {
+        setNetInfo(state);
+      }
+    });
+
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      if (isMounted) {
+        setNetInfo(state);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+      unsubscribe();
+    };
+  }, []);
+
+  return {
+    isOffline: isOffline(netInfo),
+    netInfo: netInfo ?? undefined
+  };
+};

--- a/apps/mobile/src/providers/AppProviders.tsx
+++ b/apps/mobile/src/providers/AppProviders.tsx
@@ -14,6 +14,7 @@ import { useOutboxProcessor } from '@/api/outbox/useOutboxProcessor';
 import { StatusBar } from 'expo-status-bar';
 import { initSentry } from '@/providers/sentry';
 import { initI18n } from '@/i18n';
+import { SyncStatusBanner } from '@/components/SyncStatusBanner';
 
 initSentry();
 initI18n();
@@ -80,6 +81,7 @@ export const AppProviders: React.FC = () => {
     <PaperProvider theme={paperTheme}>
       <QueryClientProvider client={queryClient}>
         <NavigationContainer theme={navigationTheme}>
+          <SyncStatusBanner />
           <AuthProvider>
             <StatusBar style="auto" />
             <AppNavigator />


### PR DESCRIPTION
## Summary
- add a global SyncStatusBanner component that surfaces offline/cached state and queued write counts across the app
- expose outbox subscription utilities with a useOutboxStatus hook plus supporting useNetworkStatus helper
- update docs, jest configuration, and add unit tests to cover the banner messaging and outbox notifications

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e06edec78c832397e4f5e29231c65d