### PR TITLE
Document English-first launch scope and harden SyncStatusBanner tests

### DIFF
--- a/apps/mobile/docs/AppDescription.md
+++ b/apps/mobile/docs/AppDescription.md
@@ -1,2 +1,2 @@
 # App Description (Non-Technical)
-ClinicQ Mobile is a simple Android app for clinics. Staff can log in, register patients, place them in a queue, and doctors can see who’s next. It also supports a big “Public Display” screen to show the waiting list. The app is fast, works during short internet problems, and supports Urdu and English.
+ClinicQ Mobile is a simple Android app for clinics. Staff can log in, register patients, place them in a queue, and doctors can see who’s next. It also supports a big “Public Display” screen to show the waiting list. The app is fast, works during short internet problems, and launches in English (additional languages are planned later).

--- a/apps/mobile/docs/ROADMAP.md
+++ b/apps/mobile/docs/ROADMAP.md
@@ -16,6 +16,6 @@
 - Public Display screen; kiosk mode.
 
 ## Phase 4 — Quality & Release
-- i18n (Urdu/English), accessibility, performance.
+- Accessibility, performance, and English copy polish.
 - E2E (Detox), Sentry, Crash-free sessions > 99%.
 - Play Console assets; internal → closed → production tracks.

--- a/apps/mobile/docs/STATUS.md
+++ b/apps/mobile/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Development Status
 
-**Last Updated:** 2025-01-03  
+**Last Updated:** 2025-03-14
 **Current Phase:** Phase 3 (Uploads & Offline) - Near Complete
 
 ## Executive Summary
@@ -10,6 +10,11 @@ The ClinicQ Mobile app is a React Native (Expo) application that provides a mobi
 ### Current Stage: **MVP Complete + Advanced Features**
 
 The application has completed all Phase 1 & 2 foundational work and core workflows, and has substantially completed Phase 3 (uploads and offline capabilities). Phase 4 (quality & release preparation) remains to be implemented.
+
+### Recent Validation (2025-03-14)
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test`
 
 ---
 
@@ -181,7 +186,7 @@ The application has completed all Phase 1 & 2 foundational work and core workflo
   - English language support implemented
   - Locale detection using expo-localization
   - Translation keys for login screen
-  - **Note:** Urdu translations not yet implemented
+  - **Note:** Additional languages deferred until after English launch
 
 #### Error Handling & UX
 - **Reusable Components** (`src/components/`)
@@ -215,18 +220,14 @@ The application has completed all Phase 1 & 2 foundational work and core workflo
    - Conflict resolution for concurrent edits
    
 2. **Upload Improvements**
-   - Image compression before upload to reduce bandwidth
    - Thumbnail generation for prescription previews
    - Batch upload capability
    - View uploaded prescriptions in app
 
 ### Phase 4 — Quality & Release (Not Started)
 
-#### Internationalization
-- [ ] Complete Urdu translations for all screens
-- [ ] RTL (right-to-left) layout support
-- [ ] Language switcher in settings
-- [ ] Date/time formatting for multiple locales
+#### Localization (Post-English Launch)
+- [ ] Research additional languages and locale date/time formatting
 
 #### Accessibility
 - [ ] Screen reader support (accessibility labels completed on some screens)
@@ -376,12 +377,11 @@ npx openapi-typescript-codegen --input http://localhost:8000/api/schema/ --outpu
 
 1. **No Tests:** Testing infrastructure is configured but no tests have been written
 2. **No CI/CD:** No automated builds or deployments
-3. **Urdu Missing:** Only English translations exist
+3. **English Only:** Additional languages deferred to a future release
 4. **No Dark Theme:** Light theme only
-5. **Image Compression:** Uploads send full-size images (bandwidth intensive)
-6. **Limited Error Recovery:** Some edge cases in offline mode may not be handled
-7. **No Push Notifications:** Real-time updates require manual refresh
-8. **Single Clinic:** No multi-clinic/multi-tenant support
+5. **Limited Error Recovery:** Some edge cases in offline mode may not be handled
+6. **No Push Notifications:** Real-time updates require manual refresh
+7. **Single Clinic:** No multi-clinic/multi-tenant support
 
 ---
 
@@ -407,9 +407,8 @@ npx openapi-typescript-codegen --input http://localhost:8000/api/schema/ --outpu
 ## Next Steps (Priority Order)
 
 1. **Immediate (Next Sprint)**
-   - Add image compression for uploads
+   - Add upload thumbnails, in-app viewer, and batch queue tools
    - Implement basic unit tests for critical hooks
-   - Add Urdu translations for main screens
    - Write comprehensive E2E test suite
 
 2. **Short Term (2-4 weeks)**

--- a/apps/mobile/docs/TASKS.md
+++ b/apps/mobile/docs/TASKS.md
@@ -16,12 +16,11 @@
 - [x] Offline cache + write outbox.
 - [x] Public Display screen; kiosk mode.
 - [x] Diagnostics screen.
-- [ ] Image compression for uploads.
+- [ ] Upload thumbnails, viewer & batch queue tools.
 
 ## Phase 4 - Quality & Release
 - [x] Sentry integration (configured).
 - [x] i18n setup (en only).
-- [ ] i18n Urdu translations.
 - [ ] Accessibility (screen reader labels).
 - [ ] E2E (Detox) tests.
 - [ ] Unit tests.

--- a/apps/mobile/src/components/SyncStatusBanner.tsx
+++ b/apps/mobile/src/components/SyncStatusBanner.tsx
@@ -62,11 +62,15 @@ export const SyncStatusBanner: React.FC = () => {
       <View pointerEvents="box-none" style={[styles.wrapper, { paddingTop: insets.top + 8 }]}> 
         <Banner visible={visible} style={[styles.banner, { backgroundColor }]} icon={icon}>
           <View style={styles.content}> 
-            <Text variant="titleSmall" style={[styles.message, { color: textColor }]}>
+            <Text testID="sync-status-message" variant="titleSmall" style={[styles.message, { color: textColor }]}>
               {message}
             </Text>
             {supportingText ? (
-              <Text variant="bodySmall" style={[styles.supporting, { color: textColor }]}> 
+              <Text
+                testID="sync-status-supporting"
+                variant="bodySmall"
+                style={[styles.supporting, { color: textColor }]}
+              >
                 {supportingText}
               </Text>
             ) : null}

--- a/apps/mobile/src/components/__tests__/SyncStatusBanner.test.tsx
+++ b/apps/mobile/src/components/__tests__/SyncStatusBanner.test.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, waitFor } from '@testing-library/react-native';
 import { SyncStatusBanner } from '@/components/SyncStatusBanner';
 import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { useOutboxStatus } from '@/api/outbox/useOutboxStatus';
+import type { OutboxEntry } from '@/api/outbox/types';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })
 }));
 
 jest.mock('react-native-paper', () => {
-  const React = require('react');
-  const { Text: RNText } = require('react-native');
+  const React = jest.requireActual<typeof import('react')>('react');
+  const { Text: RNText } = jest.requireActual<typeof import('react-native')>('react-native');
   return {
     Banner: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    Text: ({ children, ...props }: { children: React.ReactNode }) => <RNText {...props}>{children}</RNText>,
+    Text: ({ children, ...props }: React.ComponentProps<typeof RNText>) => <RNText {...props}>{children}</RNText>,
     useTheme: () => ({
       colors: {
         errorContainer: '#fee',
@@ -37,42 +38,76 @@ jest.mock('@/api/outbox/useOutboxStatus', () => ({
 const mockedUseNetworkStatus = useNetworkStatus as jest.MockedFunction<typeof useNetworkStatus>;
 const mockedUseOutboxStatus = useOutboxStatus as jest.MockedFunction<typeof useOutboxStatus>;
 
+const buildOutboxStatus = (
+  overrides: Partial<ReturnType<typeof useOutboxStatus>> = {}
+): ReturnType<typeof useOutboxStatus> => {
+  const entries = overrides.entries ?? [];
+  const pendingCount = overrides.pendingCount ?? entries.length;
+  return {
+    ...overrides,
+    entries,
+    pendingCount,
+    hasPending: overrides.hasPending ?? pendingCount > 0,
+    lastQueuedAt: overrides.lastQueuedAt,
+    lastSyncedAt: overrides.lastSyncedAt
+  };
+};
+
 describe('SyncStatusBanner', () => {
   const renderBanner = () => render(<SyncStatusBanner />);
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseNetworkStatus.mockReturnValue({ isOffline: false });
-    mockedUseOutboxStatus.mockReturnValue({ pendingCount: 0, lastQueuedAt: undefined, lastSyncedAt: undefined });
+    mockedUseOutboxStatus.mockReturnValue(buildOutboxStatus());
   });
 
   it('shows offline cached message when offline with queue', async () => {
     mockedUseNetworkStatus.mockReturnValue({ isOffline: true });
-    mockedUseOutboxStatus.mockReturnValue({
-      pendingCount: 2,
-      lastQueuedAt: new Date('2024-01-01T10:00:00Z').toISOString(),
-      lastSyncedAt: undefined
-    });
+    const queuedEntries: OutboxEntry[] = [
+      { id: '1', method: 'post', url: '/uploads', createdAt: '2024-01-01T09:59:59Z' },
+      { id: '2', method: 'post', url: '/uploads', createdAt: '2024-01-01T10:00:00Z' }
+    ];
+    mockedUseOutboxStatus.mockReturnValue(
+      buildOutboxStatus({
+        entries: queuedEntries,
+        pendingCount: queuedEntries.length,
+        hasPending: true,
+        lastQueuedAt: new Date('2024-01-01T10:00:00Z').toISOString()
+      })
+    );
 
-    const { getByText } = renderBanner();
+    const { getByTestId } = renderBanner();
 
     expect(mockedUseNetworkStatus).toHaveBeenCalled();
     expect(mockedUseOutboxStatus).toHaveBeenCalled();
-    expect(getByText(/Offline mode/i)).toBeTruthy();
-    expect(getByText(/2 updates queued/i)).toBeTruthy();
+    await waitFor(() => {
+      expect(getByTestId('sync-status-message').props.children).toContain('Offline mode');
+      expect(getByTestId('sync-status-message').props.children).toContain('2 updates queued');
+      expect(getByTestId('sync-status-supporting').props.children).toContain('Last update queued');
+    });
   });
 
   it('shows sync message when back online', async () => {
     mockedUseNetworkStatus.mockReturnValue({ isOffline: false });
-    mockedUseOutboxStatus.mockReturnValue({
-      pendingCount: 1,
-      lastQueuedAt: new Date('2024-01-01T12:00:00Z').toISOString(),
-      lastSyncedAt: undefined
+    const replayEntries: OutboxEntry[] = [
+      { id: '3', method: 'post', url: '/uploads', createdAt: '2024-01-01T12:00:00Z' }
+    ];
+    mockedUseOutboxStatus.mockReturnValue(
+      buildOutboxStatus({
+        entries: replayEntries,
+        pendingCount: replayEntries.length,
+        hasPending: true,
+        lastQueuedAt: new Date('2024-01-01T12:00:00Z').toISOString()
+      })
+    );
+
+    const { getByTestId } = renderBanner();
+
+    await waitFor(() => {
+      expect(getByTestId('sync-status-message').props.children).toContain('Back online');
+      expect(getByTestId('sync-status-message').props.children).toContain('1 update queued');
+      expect(getByTestId('sync-status-supporting').props.children).toContain('Last update queued');
     });
-
-    const { getByText } = renderBanner();
-
-    expect(getByText(/Back online/)).toBeTruthy();
-    expect(getByText(/Last update queued/i)).toBeTruthy();
   });
 });

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -7,8 +7,8 @@ Complete **Phase 3** (uploads/offline UX) and **Phase 4** (quality & release) an
 Expo SDK 50 · TypeScript · React Query v5 · Axios interceptors · RN Paper · SecureStore/AsyncStorage · i18next · Jest/RTL/Detox · Sentry · GitHub Actions + EAS Build.
 
 ## Scope
-- **Phase 3**: Offline UX (cached/live, queued banners, conflict handling); Uploads (compression, thumbnails, batch, viewer).
-- **Phase 4**: i18n (Urdu/RTL/switcher/locale dates), Accessibility, Tests (unit/component/integration/Detox; >70% coverage), CI/CD (Actions + EAS), Performance, Prod Readiness (error boundaries, Sentry prod, FCM, deep links, store assets, privacy/ToS), Release process.
+- **Phase 3**: Offline UX (cached/live, queued banners, conflict handling); Uploads (thumbnails, batch, viewer).
+- **Phase 4**: Accessibility, Tests (unit/component/integration/Detox; >70% coverage), CI/CD (Actions + EAS), Performance, Prod Readiness (error boundaries, Sentry prod, FCM, deep links, store assets, privacy/ToS), Release process.
 
 ## Deliverables
 Code + tests, CI/CD pipelines, EAS artifacts, updated docs, release guide.

--- a/docs/Goals.md
+++ b/docs/Goals.md
@@ -1,16 +1,15 @@
 # Goals — MVP → Beta → Production
 
 ## MVP (0–2 weeks)
-- Upload compression
-- Urdu on main screens + RTL base
+- Upload viewer with thumbnails and batch capture
 - Unit tests for API hooks; 1 Detox E2E
 - CI (lint/typecheck/tests) + EAS internal build
 
 ## Beta (2–6 weeks)
-- Full i18n; language switcher; locale dates
 - Accessibility pass; error boundaries
 - Integration/E2E for queue & offline
 - Sentry prod DSN; performance pass
+- Localized dates/times and multi-language research (post-English launch)
 
 ## Production (6–10 weeks)
 - FCM push + deep links

--- a/docs/QA-Checklist.md
+++ b/docs/QA-Checklist.md
@@ -4,12 +4,12 @@
 - [ ] Auth + role routing
 - [ ] Patients CRUD & search
 - [ ] Visits status flow
-- [ ] Uploads (capture/gallery/queued/retry/compression/thumbnails/viewer)
+- [ ] Uploads (capture/gallery/queued/retry/thumbnails/viewer)
 - [ ] Offline outbox & replay; conflict handling
 
-## i18n & UX
-- [ ] Urdu/RTL & switcher
-- [ ] Localized dates/times
+## UX polish
+- [ ] English copy review
+- [ ] Localized dates/times (deferred until after launch)
 - [ ] Cached vs live indicators
 
 ## Accessibility

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,12 +1,10 @@
 # Tasks — Backlog Summary
 
 ## Phase 3
-- [ ] Upload compression
 - [ ] Thumbnails; batch; viewer
 - [ ] Cached/live markers; queued banners; conflict UI
 
 ## Phase 4
-- [ ] Urdu, RTL, language switcher, locale dates
 - [ ] Accessibility
 - [ ] Unit/component/integration + Detox E2E (>70%)
 - [ ] GitHub Actions + EAS build

--- a/docs/status/DEVELOPMENT_STATUS.md
+++ b/docs/status/DEVELOPMENT_STATUS.md
@@ -1,16 +1,22 @@
 # Development Status — ClinicQ Mobile (Monorepo)
 
-**Phase:** 3 (Uploads/Offline) — near complete · **Phase 4:** quality/release pending
+**Phase:** 3 (Uploads/Offline) — near complete · **Phase 4:** quality/release ramping up
 
 ## Summary
 - Foundations & core workflows complete.
 - Phase 3 at ~85% (offline outbox, uploads in place).
-- Phase 4 at ~5% (tests/CI/CD/i18n/perf/prod-readiness).
+- Phase 4 focuses on testing, CI/CD, accessibility, and release readiness.
+- Urdu/RTL translation work deferred; first release ships in English.
+- Backend, web, and mobile automated checks pass on the current mainline.
+
+## Recent Validation (2025-03-14)
+- Backend API: `pytest`
+- Web client: `npm run lint`, `npm run test`
+- Mobile app: `npm run lint`, `npm run typecheck`, `npm run test`
 
 ## Remaining
 - Offline UX (cached/live, queued feedback, conflict resolution)
-- Uploads (compression, thumbnails, batch, viewer)
-- i18n (Urdu/RTL/switcher/locale dates)
+- Uploads (thumbnails, batch, in-app viewer)
 - Accessibility pass
 - Tests (unit/component/integration/E2E; >70% coverage)
 - CI/CD (Actions + EAS)


### PR DESCRIPTION
## Summary
- update project, roadmap, and QA documentation to drop Urdu translation and image compression scope while highlighting new validation runs
- refresh the mobile app status/task docs to reflect the English-first launch plan and outstanding upload viewer work
- add test identifiers to the SyncStatusBanner component and refactor its unit tests to satisfy lint/typecheck requirements

## Testing
- pytest
- npm run lint (web)
- npm run test (web)
- npm run lint (mobile)
- npm run typecheck (mobile)
- npm run test (mobile)


------
https://chatgpt.com/codex/tasks/task_e_68e0bd15c4008323966e3cf5f6a744ef