### PR TITLE
feat: make registration numbers configurable

### DIFF
--- a/apps/backend/api/migrations/0010_registrationnumberformat_and_expand_registration.py
+++ b/apps/backend/api/migrations/0010_registrationnumberformat_and_expand_registration.py
@@ -1,0 +1,47 @@
+import api.models
+from django.db import migrations, models
+
+
+def seed_default_format(apps, schema_editor):
+    Format = apps.get_model("api", "RegistrationNumberFormat")
+    Format.objects.get_or_create(
+        singleton_enforcer=True,
+        defaults={"digit_groups": [2, 2, 3], "separators": ["-", "-"]},
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0009_bootstrap_groups"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="RegistrationNumberFormat",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "singleton_enforcer",
+                    models.BooleanField(default=True, editable=False, unique=True),
+                ),
+                ("digit_groups", models.JSONField(default=list)),
+                ("separators", models.JSONField(default=list)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={"ordering": ["-updated_at"]},
+        ),
+        migrations.AlterField(
+            model_name="patient",
+            name="registration_number",
+            field=models.CharField(
+                max_length=15,
+                primary_key=True,
+                serialize=False,
+                unique=True,
+                validators=[api.models.validate_registration_number_format],
+            ),
+        ),
+        migrations.RunPython(seed_default_format, migrations.RunPython.noop),
+    ]

--- a/apps/backend/api/models.py
+++ b/apps/backend/api/models.py
@@ -1,14 +1,202 @@
 # Reviewed for final cleanup
 from django.db import models
 from django.core.exceptions import ValidationError
+from django.core.cache import cache
 import datetime
+import json
 import re
+DEFAULT_DIGIT_GROUPS = [2, 2, 3]
+DEFAULT_SEPARATORS = ["-", "-"]
+
+
+class RegistrationNumberFormat(models.Model):
+    """Singleton model storing the registration number formatting rules."""
+
+    singleton_enforcer = models.BooleanField(default=True, editable=False, unique=True)
+    digit_groups = models.JSONField(default=list)
+    separators = models.JSONField(default=list)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["-updated_at"]
+
+    def clean(self):
+        super().clean()
+        if not isinstance(self.digit_groups, list) or not self.digit_groups:
+            raise ValidationError({"digit_groups": "At least one digit group is required."})
+
+        if not all(isinstance(value, int) and value > 0 for value in self.digit_groups):
+            raise ValidationError({"digit_groups": "Digit groups must be positive integers."})
+
+        if sum(self.digit_groups) > 15:
+            raise ValidationError({"digit_groups": "Total digits cannot exceed 15."})
+
+        if not isinstance(self.separators, list):
+            raise ValidationError({"separators": "Separators must be a list."})
+
+        if len(self.separators) != max(len(self.digit_groups) - 1, 0):
+            raise ValidationError(
+                {
+                    "separators": (
+                        "Separators count must be exactly one less than the number of digit groups."
+                    )
+                }
+            )
+
+        allowed_separators = {"-", "+"}
+        for separator in self.separators:
+            if separator not in allowed_separators:
+                raise ValidationError(
+                    {
+                        "separators": "Only '-' and '+' separators are supported.",
+                    }
+                )
+
+        pattern_length = sum(self.digit_groups) + len(self.separators)
+        if pattern_length > 15:
+            raise ValidationError(
+                {
+                    "digit_groups": (
+                        "Total formatted length (digits + separators) cannot exceed 15 characters."
+                    )
+                }
+            )
+
+    @classmethod
+    def load(cls):
+        obj, created = cls.objects.get_or_create(
+            singleton_enforcer=True,
+            defaults={
+                "digit_groups": DEFAULT_DIGIT_GROUPS,
+                "separators": DEFAULT_SEPARATORS,
+            },
+        )
+        if created:
+            cache.delete("registration_number_format")
+        return obj
+
+    @property
+    def total_digits(self):
+        return sum(self.digit_groups)
+
+    @property
+    def formatted_length(self):
+        return self.total_digits + len(self.separators)
+
+    def as_dict(self):
+        return {
+            "digit_groups": list(self.digit_groups),
+            "separators": list(self.separators),
+            "total_digits": self.total_digits,
+            "formatted_length": self.formatted_length,
+        }
+
+    def build_pattern(self):
+        pattern = r"^"
+        groups = list(self.digit_groups)
+        separators = list(self.separators)
+        for index, group_size in enumerate(groups):
+            pattern += rf"\d{{{group_size}}}"
+            if index < len(separators):
+                pattern += re.escape(separators[index])
+        pattern += r"$"
+        return pattern
+
+    def format_value(self, numeric_value: int) -> str:
+        padded = f"{int(numeric_value):0{self.total_digits}d}"
+        formatted = padded[: self.digit_groups[0]]
+        offset = self.digit_groups[0]
+        for index, group_size in enumerate(self.digit_groups[1:]):
+            formatted += self.separators[index]
+            formatted += padded[offset : offset + group_size]
+            offset += group_size
+        return formatted
+
+    def __str__(self):
+        return json.dumps(self.as_dict())
+
+
+def get_registration_number_format(force_reload: bool = False):
+    cache_key = "registration_number_format"
+    if force_reload:
+        cache.delete(cache_key)
+
+    data = cache.get(cache_key)
+    if data:
+        return data
+
+    format_instance = RegistrationNumberFormat.load()
+    payload = {
+        **format_instance.as_dict(),
+        "pattern": format_instance.build_pattern(),
+    }
+    cache.set(cache_key, payload)
+    return payload
 
 
 def validate_registration_number_format(value):
-    """Validate that registration number follows xx-xx-xxx format"""
-    if not re.match(r"^\d{2}-\d{2}-\d{3}$", value):
-        raise ValidationError("Registration number must be in format xx-xx-xxx (e.g., 01-23-456)")
+    """Validate that registration number matches the configured format."""
+    format_config = get_registration_number_format()
+    pattern = format_config["pattern"]
+    if not re.match(pattern, value):
+        raise ValidationError(
+            "Registration number does not match the configured format."
+        )
+
+
+def ensure_format_can_fit_existing_patients(format_instance: RegistrationNumberFormat):
+    max_digits_required = 0
+    max_numeric_value = 0
+
+    for registration_number in Patient.objects.values_list("registration_number", flat=True):
+        if registration_number is None:
+            continue
+        digits = re.sub(r"\D", "", str(registration_number))
+        if not digits:
+            continue
+        max_digits_required = max(max_digits_required, len(digits))
+        numeric_value = int(digits)
+        max_numeric_value = max(max_numeric_value, numeric_value)
+
+    if max_digits_required > format_instance.total_digits:
+        raise ValidationError(
+            {
+                "digit_groups": (
+                    "Existing registration numbers require at least "
+                    f"{max_digits_required} digits."
+                )
+            }
+        )
+
+    if max_numeric_value > (10 ** format_instance.total_digits) - 1:
+        raise ValidationError(
+            {
+                "digit_groups": (
+                    "Existing registration numbers exceed the new format's capacity."
+                )
+            }
+        )
+
+
+def reformat_patients_to_format(format_instance: RegistrationNumberFormat):
+    from django.db import transaction
+
+    with transaction.atomic():
+        for patient in Patient.objects.order_by("registration_number").select_for_update():
+            digits = re.sub(r"\D", "", patient.registration_number or "")
+            if not digits:
+                continue
+            numeric_value = int(digits)
+            new_value = format_instance.format_value(numeric_value)
+            if new_value == patient.registration_number:
+                continue
+            Visit.objects.filter(patient_id=patient.registration_number).update(
+                patient_id=new_value
+            )
+            Patient.objects.filter(pk=patient.registration_number).update(
+                registration_number=new_value
+            )
 
 
 class Visit(models.Model):
@@ -59,10 +247,9 @@ class Visit(models.Model):
 
 
 class Patient(models.Model):
-    # Using CharField with custom format xx-xx-xxx for registration_number
-    # to ensure proper formatting and uniqueness
+    # Using CharField with custom format based on configuration
     registration_number = models.CharField(
-        max_length=8,
+        max_length=15,
         primary_key=True,
         unique=True,
         validators=[validate_registration_number_format],
@@ -83,23 +270,27 @@ class Patient(models.Model):
 
     @classmethod
     def generate_next_registration_number(cls):
-        """Generate the next registration number in xx-xx-xxx format"""
-        # Get the highest existing registration number
+        """Generate the next registration number based on configured format."""
+        format_instance = RegistrationNumberFormat.load()
+        total_digits = format_instance.total_digits
+
         last_patient = cls.objects.order_by("-registration_number").first()
 
         if not last_patient:
-            # First patient gets 01-00-001
-            return "01-00-001"
+            if len(format_instance.digit_groups) == 1:
+                next_number = 1
+            else:
+                trailing_digits = sum(format_instance.digit_groups[1:])
+                next_number = (10**trailing_digits) + 1
+        else:
+            numeric_part = re.sub(r"\D", "", last_patient.registration_number)
+            next_number = int(numeric_part) + 1
 
-        # Extract numeric value from existing format (remove dashes)
-        last_number_str = last_patient.registration_number.replace("-", "")
-        last_number = int(last_number_str)
+        max_number = (10 ** total_digits) - 1
+        if next_number > max_number:
+            raise ValidationError("No more registration numbers available for the configured format.")
 
-        # Increment and format as xx-xx-xxx
-        next_number = last_number + 1
-        formatted = f"{next_number:07d}"  # Zero-pad to 7 digits
-
-        return f"{formatted[:2]}-{formatted[2:4]}-{formatted[4:]}"
+        return format_instance.format_value(next_number)
 
     def save(self, *args, **kwargs):
         # Auto-generate registration number if not provided

--- a/apps/backend/api/serializers.py
+++ b/apps/backend/api/serializers.py
@@ -1,5 +1,16 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from rest_framework import serializers
-from .models import Visit, Patient, Queue, PrescriptionImage
+from .models import (
+    Visit,
+    Patient,
+    Queue,
+    PrescriptionImage,
+    RegistrationNumberFormat,
+    get_registration_number_format,
+    ensure_format_can_fit_existing_patients,
+    reformat_patients_to_format,
+)
 
 
 class PatientSerializer(serializers.ModelSerializer):
@@ -100,3 +111,87 @@ class PrescriptionImageSerializer(serializers.ModelSerializer):
         model = PrescriptionImage
         fields = ["id", "visit", "drive_file_id", "image_url", "created_at"]
         read_only_fields = ["id", "drive_file_id", "image_url", "created_at"]
+
+
+class RegistrationNumberFormatSerializer(serializers.ModelSerializer):
+    digit_groups = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=False,
+    )
+    separators = serializers.ListField(
+        child=serializers.CharField(allow_blank=False),
+        allow_empty=True,
+    )
+    total_digits = serializers.SerializerMethodField()
+    formatted_length = serializers.SerializerMethodField()
+
+    class Meta:
+        model = RegistrationNumberFormat
+        fields = ["digit_groups", "separators", "total_digits", "formatted_length"]
+
+    def get_total_digits(self, obj):
+        return obj.total_digits
+
+    def get_formatted_length(self, obj):
+        return obj.formatted_length
+
+    def validate(self, attrs):
+        digit_groups = attrs.get("digit_groups")
+        separators = attrs.get("separators")
+
+        if self.instance:
+            if digit_groups is None:
+                digit_groups = list(self.instance.digit_groups)
+            if separators is None:
+                separators = list(self.instance.separators)
+
+        if digit_groups is None:
+            digit_groups = []
+        if separators is None:
+            separators = []
+
+        if len(separators) != max(len(digit_groups) - 1, 0):
+            raise serializers.ValidationError(
+                {
+                    "separators": "Separators count must be exactly one less than the number of digit groups.",
+                }
+            )
+
+        invalid_separators = [sep for sep in separators if sep not in {"-", "+"}]
+        if invalid_separators:
+            raise serializers.ValidationError(
+                {"separators": "Only '-' and '+' separators are supported."}
+            )
+
+        total_digits = sum(digit_groups)
+        if total_digits > 15:
+            raise serializers.ValidationError(
+                {"digit_groups": "Total digits cannot exceed 15."}
+            )
+
+        formatted_length = total_digits + len(separators)
+        if formatted_length > 15:
+            raise serializers.ValidationError(
+                {
+                    "digit_groups": (
+                        "Formatted length (digits + separators) cannot exceed 15 characters."
+                    )
+                }
+            )
+
+        return attrs
+
+    def update(self, instance, validated_data):
+        instance.digit_groups = validated_data.get("digit_groups", instance.digit_groups)
+        instance.separators = validated_data.get("separators", instance.separators)
+        try:
+            instance.full_clean()
+            ensure_format_can_fit_existing_patients(instance)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.message_dict or exc.messages) from exc
+        with transaction.atomic():
+            instance.save(update_fields=["digit_groups", "separators", "updated_at"])
+            reformat_patients_to_format(instance)
+        # Refresh cache so future validations use the updated format
+        get_registration_number_format(force_reload=True)
+        return instance

--- a/apps/backend/api/urls.py
+++ b/apps/backend/api/urls.py
@@ -5,6 +5,7 @@ from .views import (
     PatientViewSet,
     QueueViewSet,
     PrescriptionImageViewSet,
+    RegistrationNumberFormatView,
     me,
     health,
 )
@@ -25,6 +26,11 @@ urlpatterns = [
     path("", include(router.urls)),
     path("auth/me/", me, name="auth-me"),
     path("health/", health, name="health"),
+    path(
+        "settings/registration-format/",
+        RegistrationNumberFormatView.as_view(),
+        name="registration-number-format",
+    ),
     # The patient search endpoint is registered as an action within
     # PatientViewSet so it will be available at /api/patients/search/
 ]

--- a/apps/backend/api/views.py
+++ b/apps/backend/api/views.py
@@ -2,6 +2,7 @@ from rest_framework import viewsets, status, permissions
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser
+from rest_framework.views import APIView
 from rest_framework.exceptions import ValidationError
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -13,13 +14,21 @@ import datetime  # Required for date operations
 import logging
 import re  # For registration number pattern matching
 
-from .models import Visit, Patient, Queue, PrescriptionImage
+from .models import (
+    Visit,
+    Patient,
+    Queue,
+    PrescriptionImage,
+    RegistrationNumberFormat,
+    get_registration_number_format,
+)
 from .serializers import (
     VisitSerializer,
     VisitStatusSerializer,
     PatientSerializer,
     QueueSerializer,
     PrescriptionImageSerializer,
+    RegistrationNumberFormatSerializer,
 )
 from .pagination import StandardResultsSetPagination
 from .google_drive import upload_prescription_image
@@ -96,6 +105,8 @@ class PatientViewSet(viewsets.ModelViewSet):
         registration numbers.
         """
         queryset = super().get_queryset()
+        format_config = get_registration_number_format()
+        pattern = re.compile(format_config["pattern"])
         reg_nums = self.request.query_params.get("registration_numbers")
         if reg_nums:
             raw_numbers = [num.strip() for num in reg_nums.split(",")]
@@ -107,17 +118,18 @@ class PatientViewSet(viewsets.ModelViewSet):
 
             numbers = []
             for num in raw_numbers:
-                # Accept formatted registration numbers (xx-xx-xxx pattern)
-                if re.match(r"^\d{2}-\d{2}-\d{3}$", num):
+                # Accept formatted registration numbers based on configuration
+                if pattern.match(num):
                     numbers.append(num)
                 # Also accept old numeric format for backward compatibility
                 # during transition
                 elif num.isdigit():
-                    if len(num) > 10:
+                    if len(num) > format_config["total_digits"]:
                         raise ValidationError(
                             {
                                 "registration_numbers": (
-                                    "Registration numbers may not exceed 10 digits."
+                                    "Registration numbers may not exceed "
+                                    f"{format_config['total_digits']} digits."
                                 ),
                             }
                         )
@@ -188,8 +200,11 @@ class PatientViewSet(viewsets.ModelViewSet):
 
         filters = Q(name__icontains=query) | Q(phone__icontains=query)
 
-        # Check if query matches registration number format (xx-xx-xxx)
-        if re.match(r"^\d{2}-\d{2}-\d{3}$", query):
+        format_config = get_registration_number_format()
+        pattern = re.compile(format_config["pattern"])
+
+        # Check if query matches registration number format
+        if pattern.match(query):
             filters |= Q(registration_number=query)
         # Also check for old numeric format for backward compatibility
         elif query.isdigit():
@@ -401,3 +416,39 @@ class PrescriptionImageViewSet(viewsets.ModelViewSet):
         )
         serializer = self.get_serializer(instance)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+class RegistrationNumberFormatView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_permissions(self):
+        if self.request.method in ("PUT", "PATCH"):
+            return [IsDoctor()]
+        return super().get_permissions()
+
+    def get(self, request):
+        instance = RegistrationNumberFormat.load()
+        serializer = RegistrationNumberFormatSerializer(instance)
+        payload = serializer.data
+        payload["pattern"] = get_registration_number_format()["pattern"]
+        return Response(payload)
+
+    def put(self, request):
+        instance = RegistrationNumberFormat.load()
+        serializer = RegistrationNumberFormatSerializer(instance, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        cache.clear()
+        payload = serializer.data
+        payload["pattern"] = get_registration_number_format()["pattern"]
+        return Response(payload)
+
+    def patch(self, request):
+        instance = RegistrationNumberFormat.load()
+        serializer = RegistrationNumberFormatSerializer(
+            instance, data=request.data, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        cache.clear()
+        payload = serializer.data
+        payload["pattern"] = get_registration_number_format()["pattern"]
+        return Response(payload)

--- a/apps/backend/server/static/js/utils.js
+++ b/apps/backend/server/static/js/utils.js
@@ -120,9 +120,35 @@ const validation = {
   },
   
   registrationNumber(value) {
-    // Validate registration number format (assuming xx-xx-xxx format)
-    const regRegex = /^\d{2}-\d{2}-\d{3}$/;
-    return regRegex.test(value);
+    const pattern = (() => {
+      if (validation._cachedRegPattern) {
+        return validation._cachedRegPattern;
+      }
+      let rawPattern = null;
+      if (typeof window !== 'undefined') {
+        if (window.REGISTRATION_NUMBER_FORMAT?.pattern) {
+          rawPattern = window.REGISTRATION_NUMBER_FORMAT.pattern;
+        } else {
+          try {
+            const stored = window.localStorage.getItem('registration_number_format');
+            if (stored) {
+              const parsed = JSON.parse(stored);
+              rawPattern = parsed?.pattern || null;
+            }
+          } catch (error) {
+            console.warn('Failed to read registration format from storage', error);
+          }
+        }
+      }
+      try {
+        validation._cachedRegPattern = rawPattern ? new RegExp(rawPattern) : /^\d{2}-\d{2}-\d{3}$/;
+      } catch (error) {
+        console.warn('Invalid registration format pattern. Falling back to default.', error);
+        validation._cachedRegPattern = /^\d{2}-\d{2}-\d{3}$/;
+      }
+      return validation._cachedRegPattern;
+    })();
+    return pattern.test(value);
   }
 };
 

--- a/apps/backend/tests/test_api.py
+++ b/apps/backend/tests/test_api.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 from django.contrib.auth.models import Group, User
 from django.core.cache import cache
@@ -6,7 +7,7 @@ from django.core.exceptions import ValidationError
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
-from api.models import Patient, Queue, Visit
+from api.models import Patient, Queue, Visit, get_registration_number_format
 
 
 class PatientCRUDTests(APITestCase):
@@ -51,12 +52,12 @@ class RegistrationNumberFormatTests(APITestCase):
         cache.clear()
 
     def test_registration_number_auto_generation(self):
-        """Test that registration numbers are auto-generated in xx-xx-xxx format"""
+        """Test that registration numbers are auto-generated using configured format"""
         patient1 = Patient.objects.create(name="Patient 1", gender="MALE")
         patient2 = Patient.objects.create(name="Patient 2", gender="FEMALE")
 
         # Verify format
-        pattern = r"^\d{2}-\d{2}-\d{3}$"
+        pattern = get_registration_number_format()["pattern"]
         self.assertRegex(patient1.registration_number, pattern)
         self.assertRegex(patient2.registration_number, pattern)
 
@@ -68,9 +69,15 @@ class RegistrationNumberFormatTests(APITestCase):
         """Test that invalid registration number formats are rejected"""
         from api.models import validate_registration_number_format
 
+        current_pattern = re.compile(get_registration_number_format()["pattern"])
+
         # Valid formats
         valid_formats = ["01-23-456", "99-99-999", "00-00-001"]
         for valid_format in valid_formats:
+            self.assertIsNotNone(
+                current_pattern.match(valid_format),
+                msg=f"Expected {valid_format} to match {current_pattern.pattern}",
+            )
             try:
                 validate_registration_number_format(valid_format)
             except ValidationError:
@@ -315,3 +322,61 @@ class PatientSearchTests(APITestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data["count"], 1)
         self.assertEqual(resp.data["results"][0]["phone"], "1234567890")
+
+
+class RegistrationNumberFormatSettingsTests(APITestCase):
+    def setUp(self):
+        cache.clear()
+        doctor_group, _ = Group.objects.get_or_create(name="Doctor")
+        assistant_group, _ = Group.objects.get_or_create(name="Assistant")
+        self.doctor = User.objects.create_user(username="doctor-settings", password="pass")
+        self.doctor.groups.add(doctor_group)
+        self.assistant = User.objects.create_user(username="assistant-settings", password="pass")
+        self.assistant.groups.add(assistant_group)
+        self.doctor_token = Token.objects.create(user=self.doctor)
+        self.assistant_token = Token.objects.create(user=self.assistant)
+
+    def test_get_current_format(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.assistant_token.key}")
+        resp = self.client.get("/api/settings/registration-format/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["digit_groups"], [2, 2, 3])
+        self.assertIn("pattern", resp.data)
+
+    def test_update_format_and_reformat_existing_numbers(self):
+        queue, _ = Queue.objects.get_or_create(name="General")
+        patient = Patient.objects.create(name="Format Test", gender="MALE")
+        visit = Visit.objects.create(
+            patient=patient,
+            queue=queue,
+            token_number=1,
+            visit_date=datetime.date.today(),
+            status="WAITING",
+        )
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
+        resp = self.client.put(
+            "/api/settings/registration-format/",
+            {"digit_groups": [3, 4, 4], "separators": ["-", "+"]},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["digit_groups"], [3, 4, 4])
+        self.assertEqual(resp.data["separators"], ["-", "+"])
+
+        updated_patient = Patient.objects.get(name="Format Test")
+        updated_visit = Visit.objects.get(pk=visit.pk)
+        new_pattern = re.compile(resp.data["pattern"])
+        self.assertRegex(updated_patient.registration_number, new_pattern)
+        self.assertEqual(updated_visit.patient_id, updated_patient.registration_number)
+
+    def test_reject_format_that_cannot_hold_existing_numbers(self):
+        Patient.objects.create(name="Format Limit", gender="MALE")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.doctor_token.key}")
+        resp = self.client.put(
+            "/api/settings/registration-format/",
+            {"digit_groups": [1, 1], "separators": ["-"]},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("digit_groups", resp.data)

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -7,6 +7,7 @@ import PatientsPage from './pages/PatientsPage.jsx';
 import PatientFormPage from './pages/PatientFormPage.jsx';
 import LoginPage from './pages/LoginPage.jsx';
 import UnauthorizedPage from './pages/UnauthorizedPage.jsx';
+import RegistrationFormatSettingsPage from './pages/RegistrationFormatSettingsPage.jsx';
 import ProtectedRoute from './components/ProtectedRoute.jsx';
 import { useAuth } from './AuthContext.jsx';
 import './App.css';
@@ -25,6 +26,7 @@ const HomePage = () => {
     { to: '/doctor', label: 'Doctor Dashboard', role: 'doctor' },
     { to: '/display', label: 'Public Queue Display', role: 'display' },
     { to: '/patients', label: 'Manage Patients', role: ['assistant', 'doctor'] },
+    { to: '/settings/registration-format', label: 'Registration Format Settings', role: 'doctor' },
   ];
 
   const linkIsVisible = (requiredRole) => {
@@ -156,6 +158,14 @@ const App = () => (
       />
       <Route path="/unauthorized" element={<UnauthorizedPage />} />
       <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/settings/registration-format"
+        element={(
+          <ProtectedRoute requiredRoles={['doctor']}>
+            <RegistrationFormatSettingsPage />
+          </ProtectedRoute>
+        )}
+      />
     </Routes>
   </div>
 );

--- a/apps/web/src/hooks/useRegistrationFormat.js
+++ b/apps/web/src/hooks/useRegistrationFormat.js
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from 'react';
+import api from '../api.js';
+
+const STORAGE_KEY = 'registration_number_format';
+
+const readFromStorage = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw);
+  } catch (error) {
+    console.warn('Failed to parse cached registration format', error);
+    return null;
+  }
+};
+
+const writeToStorage = (value) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    if (value) {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+      window.REGISTRATION_NUMBER_FORMAT = value;
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+      window.REGISTRATION_NUMBER_FORMAT = undefined;
+    }
+  } catch (error) {
+    console.warn('Failed to persist registration format', error);
+  }
+};
+
+export const useRegistrationFormat = () => {
+  const [format, setFormat] = useState(() => readFromStorage());
+  const [loading, setLoading] = useState(!format);
+  const [error, setError] = useState('');
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const response = await api.get('/settings/registration-format/');
+      setFormat(response.data);
+      writeToStorage(response.data);
+      return response.data;
+    } catch (err) {
+      console.error('Failed to load registration format', err);
+      setError('Failed to load registration format.');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!format) {
+      refresh().catch(() => {});
+    } else {
+      writeToStorage(format);
+    }
+  }, [format, refresh]);
+
+  const updateLocalFormat = useCallback((value) => {
+    setFormat(value);
+    writeToStorage(value);
+  }, []);
+
+  return {
+    format,
+    loading,
+    error,
+    refresh,
+    setFormat: updateLocalFormat,
+  };
+};
+
+export default useRegistrationFormat;

--- a/apps/web/src/pages/AssistantPage.jsx
+++ b/apps/web/src/pages/AssistantPage.jsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import api from '../api.js';
 import { firstFromListResponse } from '../utils/api.js';
+import useRegistrationFormat from '../hooks/useRegistrationFormat.js';
+import { buildExampleFromFormat } from '../utils/registrationFormat.js';
 
 const AssistantPage = () => {
   const [registrationNumber, setRegistrationNumber] = useState('');
@@ -11,6 +13,8 @@ const AssistantPage = () => {
   const [generatedToken, setGeneratedToken] = useState(null);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const { format } = useRegistrationFormat();
+  const formatExample = useMemo(() => buildExampleFromFormat(format), [format]);
 
   useEffect(() => {
     const fetchQueues = async () => {
@@ -133,8 +137,14 @@ const AssistantPage = () => {
             id="registrationNumber"
             value={registrationNumber}
             onChange={(e) => setRegistrationNumber(e.target.value)}
+            placeholder={formatExample ? `e.g. ${formatExample}` : 'Registration number'}
             className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
           />
+          {formatExample && (
+            <p className="mt-1 text-xs text-gray-500">
+              Expected format similar to <span className="font-mono">{formatExample}</span>
+            </p>
+          )}
         </div>
 
         <div>

--- a/apps/web/src/pages/PatientsPage.jsx
+++ b/apps/web/src/pages/PatientsPage.jsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import api from '../api.js';
 import { unwrapListResponse } from '../utils/api.js';
 import { TimeStamp } from '../components/index.js';
+import useRegistrationFormat from '../hooks/useRegistrationFormat.js';
+import { buildExampleFromFormat } from '../utils/registrationFormat.js';
 
 const PatientsPage = () => {
   const [patients, setPatients] = useState([]);
@@ -10,6 +12,8 @@ const PatientsPage = () => {
   const [error, setError] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const navigate = useNavigate();
+  const { format } = useRegistrationFormat();
+  const formatExample = useMemo(() => buildExampleFromFormat(format), [format]);
 
   const fetchPatients = async (term = '') => {
     setLoading(true);
@@ -65,7 +69,11 @@ const PatientsPage = () => {
       <form onSubmit={handleSearch} className="mt-4 flex flex-wrap gap-2">
         <input
           type="text"
-          placeholder="Search by name, phone, or ID"
+          placeholder={
+            formatExample
+              ? `Search by name, phone, or ID (e.g. ${formatExample})`
+              : 'Search by name, phone, or ID'
+          }
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           className="flex-grow border border-gray-300 rounded px-3 py-2"

--- a/apps/web/src/pages/RegistrationFormatSettingsPage.jsx
+++ b/apps/web/src/pages/RegistrationFormatSettingsPage.jsx
@@ -1,0 +1,282 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../api.js';
+import useRegistrationFormat from '../hooks/useRegistrationFormat.js';
+import {
+  buildExampleFromFormat,
+  buildPatternFromFormat,
+  computeDigitTotal,
+  computeFormattedLength,
+} from '../utils/registrationFormat.js';
+
+const separatorOptions = [
+  { value: '-', label: 'Dash (-)' },
+  { value: '+', label: 'Plus (+)' },
+];
+
+const normalizeGroups = (groups) =>
+  groups.map((value) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : 0;
+  });
+
+const formatErrors = (data) => {
+  if (!data || typeof data !== 'object') {
+    return 'Failed to save registration format.';
+  }
+  return Object.entries(data)
+    .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+    .join('; ');
+};
+
+const RegistrationFormatSettingsPage = () => {
+  const { format, loading, refresh, setFormat } = useRegistrationFormat();
+  const [digitGroups, setDigitGroups] = useState([2, 2, 3]);
+  const [separators, setSeparators] = useState(['-', '-']);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    if (!format && !loading) {
+      refresh().catch(() => {});
+    } else if (format) {
+      setDigitGroups(format.digit_groups || [2, 2, 3]);
+      setSeparators(format.separators || Array(Math.max((format.digit_groups || [2, 2, 3]).length - 1, 0)).fill('-'));
+    }
+  }, [format, loading, refresh]);
+
+  const normalizedGroups = useMemo(() => normalizeGroups(digitGroups), [digitGroups]);
+  const workingFormat = useMemo(
+    () => ({ digit_groups: normalizedGroups, separators }),
+    [normalizedGroups, separators],
+  );
+  const totalDigits = useMemo(() => computeDigitTotal(workingFormat), [workingFormat]);
+  const formattedLength = useMemo(
+    () => computeFormattedLength(workingFormat),
+    [workingFormat],
+  );
+
+  const validationMessages = useMemo(() => {
+    const messages = [];
+    if (!digitGroups.length) {
+      messages.push('At least one digit group is required.');
+    }
+    if (normalizedGroups.some((value) => value < 1)) {
+      messages.push('Each digit group must contain at least one digit.');
+    }
+    if (totalDigits > 15) {
+      messages.push('Total digits cannot exceed 15.');
+    }
+    if (formattedLength > 15) {
+      messages.push('Formatted length (digits plus separators) cannot exceed 15 characters.');
+    }
+    if (separators.length !== Math.max(digitGroups.length - 1, 0)) {
+      messages.push('Separators count must be one less than the number of digit groups.');
+    }
+    return messages;
+  }, [digitGroups.length, formattedLength, normalizedGroups, separators.length, totalDigits]);
+
+  const example = useMemo(() => buildExampleFromFormat(workingFormat), [workingFormat]);
+
+  const handleGroupChange = (index, value) => {
+    setDigitGroups((prev) => {
+      const next = [...prev];
+      next[index] = value === '' ? '' : Number(value);
+      return next;
+    });
+  };
+
+  const handleSeparatorChange = (index, value) => {
+    setSeparators((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  const handleAddGroup = () => {
+    setDigitGroups((prev) => [...prev, 1]);
+    setSeparators((prev) => [...prev, prev.length > 0 ? prev[prev.length - 1] : '-']);
+  };
+
+  const handleRemoveGroup = (index) => {
+    setDigitGroups((prev) => {
+      if (prev.length <= 1) {
+        return prev;
+      }
+      const next = prev.filter((_, idx) => idx !== index);
+      setSeparators((prevSeparators) => {
+        const updated = [...prevSeparators];
+        if (index < updated.length) {
+          updated.splice(index, 1);
+        } else if (updated.length) {
+          updated.pop();
+        }
+        return updated;
+      });
+      return next;
+    });
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    try {
+      const payload = {
+        digit_groups: normalizedGroups,
+        separators,
+      };
+      const response = await api.put('/settings/registration-format/', payload);
+      setFormat(response.data);
+      setSuccess('Registration number format updated successfully.');
+    } catch (err) {
+      console.error('Failed to update registration format', err);
+      if (err.response?.data) {
+        setError(formatErrors(err.response.data));
+      } else {
+        setError('Failed to update registration number format.');
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-3xl p-6">
+      <Link to="/" className="text-blue-500 hover:underline">&larr; Back to Home</Link>
+      <h1 className="mt-4 text-3xl font-bold text-gray-800">Registration Number Format</h1>
+      <p className="mt-2 text-gray-600">
+        Configure how patient registration numbers are generated and validated across the clinic. Changes apply immediately
+        and existing records will be reformatted automatically when needed.
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-6 space-y-6" noValidate>
+        <section className="rounded-lg bg-white p-4 shadow">
+          <h2 className="text-lg font-semibold text-gray-800">Digit Groups</h2>
+          <p className="text-sm text-gray-500">
+            Specify how digits are grouped. You can add or remove groups and control the separator between them.
+          </p>
+
+          <div className="mt-4 space-y-4">
+            {digitGroups.map((group, index) => (
+              <div key={`group-${index}`} className="flex flex-wrap items-end gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700" htmlFor={`group-${index}`}>
+                    Digits in group {index + 1}
+                  </label>
+                  <input
+                    id={`group-${index}`}
+                    type="number"
+                    min="1"
+                    max="15"
+                    value={group}
+                    onChange={(event) => handleGroupChange(index, event.target.value)}
+                    className="mt-1 w-28 rounded border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  />
+                </div>
+                {index < digitGroups.length - 1 && (
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700" htmlFor={`separator-${index}`}>
+                      Separator after group {index + 1}
+                    </label>
+                    <select
+                      id={`separator-${index}`}
+                      value={separators[index] || '-'}
+                      onChange={(event) => handleSeparatorChange(index, event.target.value)}
+                      className="mt-1 w-40 rounded border border-gray-300 px-3 py-2 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    >
+                      {separatorOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+                {digitGroups.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveGroup(index)}
+                    className="text-sm text-red-600 hover:underline"
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={handleAddGroup}
+            className="mt-4 rounded border border-indigo-500 px-4 py-2 text-sm font-medium text-indigo-600 hover:bg-indigo-50"
+          >
+            Add digit group
+          </button>
+        </section>
+
+        <section className="rounded-lg bg-white p-4 shadow">
+          <h2 className="text-lg font-semibold text-gray-800">Preview</h2>
+          <div className="mt-2 grid gap-2 md:grid-cols-2">
+            <div>
+              <p className="text-sm font-medium text-gray-600">Example</p>
+              <p className="mt-1 rounded bg-gray-100 px-3 py-2 font-mono text-sm">{example || '—'}</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-600">Regex pattern</p>
+              <p className="mt-1 break-all rounded bg-gray-100 px-3 py-2 font-mono text-xs">
+                {format?.pattern || buildPatternFromFormat(workingFormat)}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-600">Total digits</p>
+              <p className="mt-1 font-semibold text-gray-800">{totalDigits}</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-600">Formatted length</p>
+              <p className="mt-1 font-semibold text-gray-800">{formattedLength}</p>
+            </div>
+          </div>
+        </section>
+
+        {validationMessages.length > 0 && (
+          <div className="rounded border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-800">
+            <p className="font-semibold">Please address the following:</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              {validationMessages.map((message) => (
+                <li key={message}>{message}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {error && (
+          <p className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700" role="alert">
+            {error}
+          </p>
+        )}
+
+        {success && (
+          <p className="rounded border border-green-300 bg-green-50 p-3 text-sm text-green-700" role="status">
+            {success}
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="submit"
+            disabled={saving || validationMessages.length > 0}
+            className="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow disabled:cursor-not-allowed disabled:bg-indigo-300"
+          >
+            {saving ? 'Saving...' : 'Save format'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default RegistrationFormatSettingsPage;

--- a/apps/web/src/utils/registrationFormat.js
+++ b/apps/web/src/utils/registrationFormat.js
@@ -1,0 +1,60 @@
+export const buildExampleFromFormat = (format) => {
+  if (!format || !Array.isArray(format.digit_groups) || format.digit_groups.length === 0) {
+    return '';
+  }
+  let counter = 1;
+  const segments = format.digit_groups.map((size) => {
+    const numericSize = Number(size) || 0;
+    if (numericSize <= 0) {
+      return ''.padStart(Math.max(0, numericSize), 'X');
+    }
+    let segment = '';
+    for (let index = 0; index < numericSize; index += 1) {
+      segment += ((counter + index) % 10).toString();
+    }
+    counter += numericSize;
+    return segment;
+  });
+  return segments
+    .map((segment, index) => {
+      if (index === 0) {
+        return segment;
+      }
+      const separator = format.separators?.[index - 1] ?? '';
+      return `${separator}${segment}`;
+    })
+    .join('');
+};
+
+export const buildPatternFromFormat = (format) => {
+  if (!format || !Array.isArray(format.digit_groups) || format.digit_groups.length === 0) {
+    return '';
+  }
+  let pattern = '^';
+  format.digit_groups.forEach((size, index) => {
+    const digits = Math.max(0, Number(size) || 0);
+    pattern += `\\d{${digits}}`;
+    if (index < (format.separators?.length || 0)) {
+      const separator = format.separators[index] ?? '';
+      pattern += separator.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
+    }
+  });
+  pattern += '$';
+  return pattern;
+};
+
+export const computeFormattedLength = (format) => {
+  if (!format || !Array.isArray(format.digit_groups)) {
+    return 0;
+  }
+  const digits = format.digit_groups.reduce((sum, value) => sum + Math.max(0, Number(value) || 0), 0);
+  const separators = Array.isArray(format.separators) ? format.separators.length : 0;
+  return digits + separators;
+};
+
+export const computeDigitTotal = (format) => {
+  if (!format || !Array.isArray(format.digit_groups)) {
+    return 0;
+  }
+  return format.digit_groups.reduce((sum, value) => sum + Math.max(0, Number(value) || 0), 0);
+};


### PR DESCRIPTION
## Summary
- add a persistent RegistrationNumberFormat model, migration, and API endpoints to configure registration-number structure
- reformat existing patient and visit records when the format changes and update validation/search logic to honor the dynamic pattern
- build a web settings page and shared hook for editing the format, plus surface examples across assistant and patients views

## Testing
- python manage.py test tests.test_api


------
https://chatgpt.com/codex/tasks/task_e_68e248003e1c83238ab345db566ce1de