### PR TITLE
Ensure frontend tests run in CI mode

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Run frontend tests
         working-directory: apps/web
+        env:
+          CI: 'true'
         run: npm test -- --runInBand --watchAll=false
 
       - name: Build frontend


### PR DESCRIPTION
## Summary
- set the frontend test step to run with CI mode enabled so Jest does not wait for watch input

## Testing
- `CI=true npm test -- --runInBand --watchAll=false` *(fails: existing Jest parsing and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e25e511a188323b9fce0a597957b5a