### PR TITLE
Enable pip caching in backend CI workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: apps/backend/requirements*.txt
 
       - name: Install backend dependencies
         working-directory: apps/backend


### PR DESCRIPTION
## Summary
- enable pip caching for backend CI by configuring actions/setup-python
- ensure the cache busts when backend requirements files change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e25e50080083239981ecd552d71c11