### PR TITLE
Fail workflow on lint errors

### DIFF
--- a/.github/workflows/android-ci.yml.disabled
+++ b/.github/workflows/android-ci.yml.disabled
@@ -25,7 +25,7 @@ jobs:
         run: ./gradlew test
 
       - name: Lint (best effort)
-        run: ./gradlew lintDebug || true
+        run: ./gradlew lintDebug
 
       - name: Assemble debug APK
         run: ./gradlew assembleDebug


### PR DESCRIPTION
## Summary
- remove the best-effort guard from the lint step so lint failures stop the job

## Testing
- ./gradlew lintDebug *(fails: missing Android SDK in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68e25e4ff6688323bddfa8d1e23b34e9