### PR TITLE
Fix backend dev dependency installation in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -r requirements.txt
-        pip install -U -r requirements-dev.txt # -U to upgrade if needed
+        pip install -r requirements-dev.txt # install pinned dev dependencies
 
     - name: Format with Black (Backend)
       working-directory: ./apps/backend


### PR DESCRIPTION
## Summary
- remove the upgrade flag from the backend dev dependency install step so CI sticks to pinned versions

## Testing
- python -m venv .venv-ci && source .venv-ci/bin/activate && pip install -r requirements.txt && pip install -r requirements-dev.txt

------
https://chatgpt.com/codex/tasks/task_e_68e25e52f2608323a1cc55607518b5a8