### PR TITLE
Set CI env for mobile tests

### DIFF
--- a/.github/workflows/mobile-eas-build.yml
+++ b/.github/workflows/mobile-eas-build.yml
@@ -33,6 +33,8 @@ jobs:
         run: npm ci
 
       - name: Run tests
+        env:
+          CI: 'true'
         run: |
           npm run lint
           npm run typecheck


### PR DESCRIPTION
## Summary
- ensure the Run tests step in the mobile EAS workflow runs with CI=true to avoid interactive prompts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e25e5487948323bfca8f7224c0dc75