### PR TITLE
Update compose configs to use DJANGO_DEBUG

### DIFF
--- a/docs/ops/DEPLOYMENT_GUIDE.md
+++ b/docs/ops/DEPLOYMENT_GUIDE.md
@@ -24,7 +24,7 @@ Edit `.env` with your production values:
 ```bash
 # Required for production
 SECRET_KEY=your_strong_random_secret_key_here
-DEBUG=false
+DJANGO_DEBUG=false
 DJANGO_ALLOWED_HOSTS=yourdomain.com,www.yourdomain.com
 DATABASE_URL=postgresql://username:password@host:5432/dbname
 CORS_ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
@@ -138,7 +138,7 @@ If refreshing frontend routes returns 404:
 
 Before going to production:
 
-- [ ] Set `DEBUG=false`
+- [ ] Set `DJANGO_DEBUG=false`
 - [ ] Use a strong, random `SECRET_KEY`
 - [ ] Configure `DJANGO_ALLOWED_HOSTS` properly
 - [ ] Set all security headers appropriately

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -16,7 +16,7 @@ This guide outlines how to deploy the ClinicQ project in a traditional server en
 Create a `.env` file (an example is provided at `deploy/.env.example`) with values for:
 
 * `SECRET_KEY` – Django secret key
-* `DEBUG` – set to `False` in production
+* `DJANGO_DEBUG` – set to `False` in production
 * `DJANGO_ALLOWED_HOSTS` – comma‑separated list of allowed hostnames
 * `DATABASE_URL` – connection string for PostgreSQL
 * Optional superuser variables: `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_EMAIL`, `DJANGO_SUPERUSER_PASSWORD`
@@ -85,7 +85,7 @@ Install the following software on the host machine:
 Create a `.env` file based on [`deploy/.env.example`](../deploy/.env.example) and adjust the values for your environment. Important variables include:
 
 - `SECRET_KEY` – Django secret key
-- `DEBUG` – set to `False` in production
+- `DJANGO_DEBUG` – set to `False` in production
 - `DJANGO_ALLOWED_HOSTS` – comma-separated hostnames that can serve the app
 - `DATABASE_URL` – PostgreSQL connection string
 - `DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_EMAIL`, `DJANGO_SUPERUSER_PASSWORD` – optional initial superuser

--- a/infra/deploy/.env.example
+++ b/infra/deploy/.env.example
@@ -2,7 +2,7 @@
 # SECURITY WARNING: keep the secret key used in production secret!
 # Generate a new one for production, e.g., using python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
 SECRET_KEY=your_production_secret_key_here
-DEBUG=False
+DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=your_domain.com,www.your_domain.com,localhost,127.0.0.1
 
 # Database Settings (PostgreSQL)

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -21,7 +21,7 @@ services:
   backend:
     environment:
       - SECRET_KEY=${SECRET_KEY}
-      - DEBUG=false
+      - DJANGO_DEBUG=false
       - DJANGO_ALLOWED_HOSTS=${DJANGO_ALLOWED_HOSTS}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-clinicq_prod_user}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-clinicq_prod_db}
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - "8000:8000"
     environment:
       - SECRET_KEY=django_insecure_local_dev_secret_key_!@#%^&*()
-      - DEBUG=True
+      - DJANGO_DEBUG=True
       - DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,backend
       - DATABASE_URL=postgresql://clinicq_dev_user:clinicq_dev_password@db:5432/clinicq_dev_db
       - DJANGO_SUPERUSER_USERNAME=admin


### PR DESCRIPTION
## Summary
- update compose configurations and env samples to export DJANGO_DEBUG instead of DEBUG
- align deployment documentation with the DJANGO_DEBUG variable name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2683eea2883238c58cb807da247c5