### PR TITLE
Add committed gdrive secret placeholder and update infra docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,10 @@ build/
 secrets/*.json
 !secrets/*.example
 !secrets/.gitkeep
+infra/secrets/*.json
+!infra/secrets/gdrive_service.json
+!infra/secrets/*.example
+!infra/secrets/.gitkeep
 deploy/*.json
 !deploy/*.example
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -66,11 +66,10 @@ See `docs/ops/DEPLOYMENT_GUIDE.md` for complete production deployment instructio
 
 ### Secrets Management
 
-1. Copy example files:
-   ```bash
-   cp secrets/gdrive_service_account.json.example secrets/gdrive_service.json
-   ```
+1. A placeholder `infra/secrets/gdrive_service.json` is committed so Docker secrets resolve during development.
 
-2. Fill in actual credentials (never commit these!)
+2. Before deploying, replace the placeholder with real credentials supplied by your secret manager **outside of version control** (e.g., copy the managed secret into place on the server but do **not** commit the change).
 
-3. Reference in docker-compose using secrets configuration
+3. `.gitignore` is configured to ignore other JSON files in this directory. Keep any additional secret material out of Git and manage it through your secret management process.
+
+4. Reference the JSON file in docker-compose using the secrets configuration as usual.

--- a/infra/secrets/gdrive_service.json
+++ b/infra/secrets/gdrive_service.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "your-project-id",
+  "private_key_id": "your-private-key-id",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY_HERE\n-----END PRIVATE KEY-----\n",
+  "client_email": "your-service-account@your-project-id.iam.gserviceaccount.com",
+  "client_id": "your-client-id",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/your-service-account%40your-project-id.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
## Summary
- add a committed placeholder for the Google Drive service account secret so Docker secrets resolve
- update the infra README to explain how to replace the placeholder with real credentials outside of Git
- extend the gitignore to keep other infra secrets JSON files out of version control while allowing the placeholder

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2685c61bc8323b72be77d296584f5