### PR TITLE
Align mobile client with DRF token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ curl -X POST http://127.0.0.1:8000/api/auth/login/ \
   -d '{"username":"admin","password":"admin123"}'
 ```
 
+The API responds with `{ "token": "..." }`. Include that value in subsequent requests using `Authorization: Token <token>`.
+
 ### Troubleshooting
 
 | Issue | Solution |

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -24,7 +24,7 @@ To keep the repository free of binary blobs, icon and splash assets are not comm
 
 ## Key features
 
-- Secure login with JWT refresh and encrypted token storage
+- Secure login with DRF token auth and encrypted token storage
 - Role-based navigation for assistants and doctors
 - Patients and visits management with optimistic updates
 - Photo uploads with progress, retry, and offline queuing

--- a/apps/mobile/docs/API.md
+++ b/apps/mobile/docs/API.md
@@ -1,7 +1,7 @@
 # API & Interfaces
 ## Auth
-- `POST /api/auth/login/` → { access, refresh } or { token }
-- `POST /api/auth/refresh/` → { access } (if JWT)
+- `POST /api/auth/login/` → { token }
+- Clients send `Authorization: Token <token>` on subsequent requests. Tokens are opaque DRF auth tokens with no refresh endpoint.
 - `GET /api/auth/me/` → { id, username, roles[] }
 
 ## Patients

--- a/apps/mobile/docs/ARCHITECTURE.md
+++ b/apps/mobile/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ app/
   services/     # uploads, notifications (later)
   utils/        # validators, date
 ```
-- **Auth:** JWT (access+refresh). Secure storage at rest.
+- **Auth:** DRF token auth (single opaque token). Secure storage at rest.
 - **Data:** React Query cache; pagination; optimistic updates where safe.
 - **Offline:** Persisted cache + queued writes with idempotency keys.
 - **Uploads:** Multipart with progress; compress large images on-device.

--- a/apps/mobile/docs/FINAL_PROMPT.md
+++ b/apps/mobile/docs/FINAL_PROMPT.md
@@ -14,7 +14,7 @@ Deliver an MVP with login, role routing (assistant/doctor), patients, queue, upl
 
 ## Steps
 1. Scaffold app; add `.env` for `SERVER_URL`.
-2. Implement `api/client` using generated OpenAPI types; axios interceptors for JWT.
+2. Implement `api/client` using generated OpenAPI types; axios interceptors for DRF token auth.
 3. Screens: Login → role routing → Assistant/Doctor dashboards.
 4. Patients: list/search/detail/form (zod validation).
 5. Visits: list/enqueue/update; optimistic updates where safe.

--- a/apps/mobile/docs/README.md
+++ b/apps/mobile/docs/README.md
@@ -12,7 +12,7 @@ This pack defines how to build a **separate Android app** that uses the **same D
 - *(optional later)* **packages/api-client** — generated typed client from OpenAPI.
 
 ## Highlights
-- JWT auth for both clients, identical endpoints & roles.
+- DRF token auth for both clients, identical endpoints & roles.
 - Shared OpenAPI schema → generated clients for web & mobile.
 - Mobile adds offline cache + write outbox; uploads via camera/gallery.
 - Release gates: schema changes must regenerate clients before merge.

--- a/apps/mobile/docs/STATUS.md
+++ b/apps/mobile/docs/STATUS.md
@@ -20,9 +20,13 @@ The application has completed all Phase 1 & 2 foundational work and the Phase 3 
 
 ## Feature Readiness Overview
 
+### Decision Log
+
+- **2025-03-21 — Auth Tokens**: Confirmed that both web and mobile clients will continue using the existing DRF token login. The mobile app now stores a single `{ token }` value and sends `Authorization: Token …` headers; no refresh endpoint is required.
+
 ### ✅ Ready to Ship (feature-complete & stable in manual testing)
 
-- **Authentication & Role Routing** – Credential login with JWT storage/refresh and role-sensitive navigation across assistant and doctor tab stacks. (`src/screens/LoginScreen.tsx`, `src/api/client.ts`, `src/navigation/index.tsx`)
+- **Authentication & Role Routing** – Credential login with DRF token storage (single token) and role-sensitive navigation across assistant and doctor tab stacks. (`src/screens/LoginScreen.tsx`, `src/api/client.ts`, `src/navigation/index.tsx`)
 - **Patient Management** – Searchable patient lists, detail view, and create/edit flows with optimistic cache updates and offline notices. (`src/screens/PatientsListScreen.tsx`, `src/screens/PatientDetailScreen.tsx`, `src/screens/PatientFormScreen.tsx`)
 - **Visit Queue Operations** – Assistant queue management, doctor workflow, detail drill-down, and conflict handling with optimistic updates. (`src/screens/VisitsQueueScreen.tsx`, `src/screens/DoctorQueueScreen.tsx`, `src/api/hooks/useVisits.ts`)
 - **Uploads Hub** – Camera/gallery intake, batch uploads with progress, offline queuing, and gallery of historical prescriptions. (`src/screens/UploadManagerScreen.tsx`, `src/api/hooks/useUploads.ts`)

--- a/apps/mobile/src/api/generated/client.ts
+++ b/apps/mobile/src/api/generated/client.ts
@@ -1,10 +1,10 @@
 import type {
+  AuthTokenResponse,
   HealthResponse,
   LoginRequest,
   PaginatedResponse,
   Patient,
   PatientRequest,
-  TokenPair,
   UploadRequest,
   UserProfile,
   VersionResponse,
@@ -17,11 +17,7 @@ export class GeneratedApiClient {
   constructor(private readonly http: AxiosInstance) {}
 
   login(body: LoginRequest) {
-    return this.http.post<TokenPair>('/api/auth/login/', body);
-  }
-
-  refresh(body: { refresh: string }) {
-    return this.http.post<{ access: string }>('/api/auth/refresh/', body);
+    return this.http.post<AuthTokenResponse>('/api/auth/login/', body);
   }
 
   me() {
@@ -76,6 +72,6 @@ export class GeneratedApiClient {
   }
 }
 
-export type { LoginRequest, TokenPair, UserProfile, Patient, Visit };
+export type { LoginRequest, AuthTokenResponse, UserProfile, Patient, Visit };
 export type { PatientRequest, VisitRequest, UploadRequest, PaginatedResponse };
 export type { HealthResponse, VersionResponse };

--- a/apps/mobile/src/api/generated/types.ts
+++ b/apps/mobile/src/api/generated/types.ts
@@ -1,6 +1,5 @@
-export interface TokenPair {
-  access: string;
-  refresh?: string;
+export interface AuthTokenResponse {
+  token: string;
 }
 
 export interface LoginRequest {

--- a/apps/mobile/src/api/outbox/replay.ts
+++ b/apps/mobile/src/api/outbox/replay.ts
@@ -13,7 +13,7 @@ client.interceptors.request.use(async (config) => {
   const token = await secureStore.getString(STORAGE_KEYS.token);
   if (token) {
     const headers = AxiosHeaders.from((config.headers ?? {}) as AxiosRequestHeaders);
-    headers.set('Authorization', `Bearer ${token}`);
+    headers.set('Authorization', `Token ${token}`);
     config.headers = headers;
   }
   return config;

--- a/apps/mobile/src/components/Button.tsx
+++ b/apps/mobile/src/components/Button.tsx
@@ -10,13 +10,14 @@ const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 export type ButtonVariant = 'primary' | 'secondary' | 'glass';
 
 type Props = {
-  label: string;
+  label?: string;
   onPress?: () => void;
   variant?: ButtonVariant;
   disabled?: boolean;
   loading?: boolean;
   style?: StyleProp<ViewStyle>;
   icon?: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 export const Button: React.FC<Props> = ({
@@ -26,7 +27,8 @@ export const Button: React.FC<Props> = ({
   disabled,
   loading,
   style,
-  icon
+  icon,
+  children
 }) => {
   const scale = useSharedValue(1);
 
@@ -44,10 +46,15 @@ export const Button: React.FC<Props> = ({
     opacity: disabled ? 0.6 : 1
   }));
 
+  const resolvedLabel = loading ? '...' : children ?? label ?? '';
   const content = (
     <>
       {icon ? icon : null}
-      <Text style={[styles.label, variant === 'glass' ? styles.labelGlass : null]}>{loading ? '...' : label}</Text>
+      {typeof resolvedLabel === 'string' || typeof resolvedLabel === 'number' ? (
+        <Text style={[styles.label, variant === 'glass' ? styles.labelGlass : null]}>{resolvedLabel}</Text>
+      ) : (
+        resolvedLabel
+      )}
     </>
   );
 

--- a/apps/mobile/src/constants/index.ts
+++ b/apps/mobile/src/constants/index.ts
@@ -5,7 +5,6 @@ export const ROLES = {
 
 export const STORAGE_KEYS = {
   token: 'clinicq/token',
-  refreshToken: 'clinicq/refresh-token',
   outbox: 'clinicq/outbox',
   queryCache: 'clinicq/query-cache'
 } as const;

--- a/apps/mobile/src/features/auth/AuthContext.tsx
+++ b/apps/mobile/src/features/auth/AuthContext.tsx
@@ -27,7 +27,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
     setIsLoading(true);
     try {
       const response = await apiClient.login({ username, password });
-      await authStorage.persistTokens({ access: response.data.access, refresh: response.data.refresh });
+      await authStorage.persistToken(response.data.token);
       await loadProfile();
     } finally {
       setIsLoading(false);
@@ -35,7 +35,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   }, [loadProfile]);
 
   const logout = useCallback(async () => {
-    await authStorage.clearTokens();
+    await authStorage.clearToken();
     setUser(null);
     Sentry.setUser(null);
   }, []);
@@ -47,7 +47,7 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
   useEffect(() => {
     const bootstrap = async () => {
       try {
-        await authStorage.loadTokens();
+        await authStorage.loadToken();
         await loadProfile();
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- update the Expo API client, auth context, and generated types to use single-value DRF tokens and Authorization: Token headers
- remove JWT refresh assumptions across mobile docs and README entries, documenting the token-based decision
- allow the custom Button to render children text while keeping outbox replay and storage aligned with token auth

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e28eeb28348323886849ef7f04518f